### PR TITLE
Backport DRAW_TILE fixes 3-4% speed benefit

### DIFF
--- a/source/snes9x/gfx.cpp
+++ b/source/snes9x/gfx.cpp
@@ -4,7 +4,6 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
-
 #include "snes9x.h"
 #include "ppu.h"
 #include "tile.h"
@@ -47,11 +46,6 @@ bool8 S9xGraphicsInit (void)
 	S9xInitTileRenderer();
 	ZeroMemory(BlackColourMap, 256 * sizeof(uint16));
 
-#ifdef GFX_MULTI_FORMAT
-	if (GFX.BuildPixel == NULL)
-		S9xSetRenderPixelFormat(RGB565);
-#endif
-
 	GFX.DoInterlace = 0;
 	GFX.InterlaceFrame = 0;
 	GFX.RealPPL = GFX.Pitch >> 1;
@@ -60,7 +54,6 @@ bool8 S9xGraphicsInit (void)
 	Settings.BG_Forced = 0;
 	S9xFixColourBrightness();
 
-	GFX.X2   = (uint16 *) malloc(sizeof(uint16) * 0x10000);
 	GFX.ZERO = (uint16 *) malloc(sizeof(uint16) * 0x10000);
 
 	GFX.ScreenSize = GFX.Pitch / 2 * SNES_HEIGHT_EXTENDED * (Settings.SupportHiRes ? 2 : 1);
@@ -68,36 +61,10 @@ bool8 S9xGraphicsInit (void)
 	GFX.ZBuffer    = (uint8 *)  malloc(GFX.ScreenSize);
 	GFX.SubZBuffer = (uint8 *)  malloc(GFX.ScreenSize);
 
-	if (!GFX.X2 || !GFX.ZERO || !GFX.SubScreen || !GFX.ZBuffer || !GFX.SubZBuffer)
+	if (!GFX.ZERO || !GFX.SubScreen || !GFX.ZBuffer || !GFX.SubZBuffer)
 	{
 		S9xGraphicsDeinit();
 		return (FALSE);
-	}
-
-    // Lookup table for color addition
-	ZeroMemory(GFX.X2, 0x10000 * sizeof(uint16));
-	for (uint32 r = 0; r <= MAX_RED; r++)
-	{
-		uint32	r2 = r << 1;
-		if (r2 > MAX_RED)
-			r2 = MAX_RED;
-
-		for (uint32 g = 0; g <= MAX_GREEN; g++)
-		{
-			uint32	g2 = g << 1;
-			if (g2 > MAX_GREEN)
-				g2 = MAX_GREEN;
-
-			for (uint32 b = 0; b <= MAX_BLUE; b++)
-			{
-				uint32	b2 = b << 1;
-				if (b2 > MAX_BLUE)
-					b2 = MAX_BLUE;
-
-				GFX.X2[BUILD_PIXEL2(r, g, b)] = BUILD_PIXEL2(r2, g2, b2);
-				GFX.X2[BUILD_PIXEL2(r, g, b) & ~ALPHA_BITS_MASK] = BUILD_PIXEL2(r2, g2, b2);
-			}
-		}
 	}
 
 	// Lookup table for 1/2 color subtraction
@@ -137,7 +104,6 @@ bool8 S9xGraphicsInit (void)
 
 void S9xGraphicsDeinit (void)
 {
-	if (GFX.X2)         { free(GFX.X2);         GFX.X2         = NULL; }
 	if (GFX.ZERO)       { free(GFX.ZERO);       GFX.ZERO       = NULL; }
 	if (GFX.SubScreen)  { free(GFX.SubScreen);  GFX.SubScreen  = NULL; }
 	if (GFX.ZBuffer)    { free(GFX.ZBuffer);    GFX.ZBuffer    = NULL; }
@@ -2122,123 +2088,3 @@ void S9xDrawCrosshair (const char *crosshair, uint8 fgcolor, uint8 bgcolor, int1
 		}
 	}
 }
-
-#ifdef GFX_MULTI_FORMAT
-
-static uint32 BuildPixelRGB565  (uint32, uint32, uint32);
-static uint32 BuildPixelRGB555  (uint32, uint32, uint32);
-static uint32 BuildPixelBGR565  (uint32, uint32, uint32);
-static uint32 BuildPixelBGR555  (uint32, uint32, uint32);
-static uint32 BuildPixelGBR565  (uint32, uint32, uint32);
-static uint32 BuildPixelGBR555  (uint32, uint32, uint32);
-static uint32 BuildPixelRGB5551 (uint32, uint32, uint32);
-
-static uint32 BuildPixel2RGB565  (uint32, uint32, uint32);
-static uint32 BuildPixel2RGB555  (uint32, uint32, uint32);
-static uint32 BuildPixel2BGR565  (uint32, uint32, uint32);
-static uint32 BuildPixel2BGR555  (uint32, uint32, uint32);
-static uint32 BuildPixel2GBR565  (uint32, uint32, uint32);
-static uint32 BuildPixel2GBR555  (uint32, uint32, uint32);
-static uint32 BuildPixel2RGB5551 (uint32, uint32, uint32);
-
-static void DecomposePixelRGB565  (uint32, uint32 &, uint32 &, uint32 &);
-static void DecomposePixelRGB555  (uint32, uint32 &, uint32 &, uint32 &);
-static void DecomposePixelBGR565  (uint32, uint32 &, uint32 &, uint32 &);
-static void DecomposePixelBGR555  (uint32, uint32 &, uint32 &, uint32 &);
-static void DecomposePixelGBR565  (uint32, uint32 &, uint32 &, uint32 &);
-static void DecomposePixelGBR555  (uint32, uint32 &, uint32 &, uint32 &);
-static void DecomposePixelRGB5551 (uint32, uint32 &, uint32 &, uint32 &);
-
-#define _BUILD_PIXEL(F) \
-static uint32 BuildPixel##F (uint32 R, uint32 G, uint32 B) \
-{ \
-	return (BUILD_PIXEL_##F(R, G, B)); \
-} \
-\
-static uint32 BuildPixel2##F (uint32 R, uint32 G, uint32 B) \
-{ \
-	return (BUILD_PIXEL2_##F(R, G, B)); \
-} \
-\
-static void DecomposePixel##F (uint32 pixel, uint32 &R, uint32 &G, uint32 &B) \
-{ \
-	DECOMPOSE_PIXEL_##F(pixel, R, G, B); \
-}
-
-_BUILD_PIXEL(RGB565)
-_BUILD_PIXEL(RGB555)
-_BUILD_PIXEL(BGR565)
-_BUILD_PIXEL(BGR555)
-_BUILD_PIXEL(GBR565)
-_BUILD_PIXEL(GBR555)
-_BUILD_PIXEL(RGB5551)
-
-#define _BUILD_SETUP(F) \
-GFX.BuildPixel             = BuildPixel##F; \
-GFX.BuildPixel2            = BuildPixel2##F; \
-GFX.DecomposePixel         = DecomposePixel##F; \
-RED_LOW_BIT_MASK           = RED_LOW_BIT_MASK_##F; \
-GREEN_LOW_BIT_MASK         = GREEN_LOW_BIT_MASK_##F; \
-BLUE_LOW_BIT_MASK          = BLUE_LOW_BIT_MASK_##F; \
-RED_HI_BIT_MASK            = RED_HI_BIT_MASK_##F; \
-GREEN_HI_BIT_MASK          = GREEN_HI_BIT_MASK_##F; \
-BLUE_HI_BIT_MASK           = BLUE_HI_BIT_MASK_##F; \
-MAX_RED                    = MAX_RED_##F; \
-MAX_GREEN                  = MAX_GREEN_##F; \
-MAX_BLUE                   = MAX_BLUE_##F; \
-SPARE_RGB_BIT_MASK         = SPARE_RGB_BIT_MASK_##F; \
-GREEN_HI_BIT               = ((MAX_GREEN_##F + 1) >> 1); \
-RGB_LOW_BITS_MASK          = (RED_LOW_BIT_MASK_##F | GREEN_LOW_BIT_MASK_##F | BLUE_LOW_BIT_MASK_##F); \
-RGB_HI_BITS_MASK           = (RED_HI_BIT_MASK_##F  | GREEN_HI_BIT_MASK_##F  | BLUE_HI_BIT_MASK_##F); \
-RGB_HI_BITS_MASKx2         = (RED_HI_BIT_MASK_##F  | GREEN_HI_BIT_MASK_##F  | BLUE_HI_BIT_MASK_##F) << 1; \
-RGB_REMOVE_LOW_BITS_MASK   = ~RGB_LOW_BITS_MASK; \
-FIRST_COLOR_MASK           = FIRST_COLOR_MASK_##F; \
-SECOND_COLOR_MASK          = SECOND_COLOR_MASK_##F; \
-THIRD_COLOR_MASK           = THIRD_COLOR_MASK_##F; \
-ALPHA_BITS_MASK            = ALPHA_BITS_MASK_##F; \
-FIRST_THIRD_COLOR_MASK     = FIRST_COLOR_MASK | THIRD_COLOR_MASK; \
-TWO_LOW_BITS_MASK          = RGB_LOW_BITS_MASK | (RGB_LOW_BITS_MASK << 1); \
-HIGH_BITS_SHIFTED_TWO_MASK = ((FIRST_COLOR_MASK | SECOND_COLOR_MASK | THIRD_COLOR_MASK) & ~TWO_LOW_BITS_MASK) >> 2;
-
-bool8 S9xSetRenderPixelFormat (int format)
-{
-	GFX.PixelFormat = format;
-
-	switch (format)
-	{
-		case RGB565:
-			_BUILD_SETUP(RGB565)
-			return (TRUE);
-
-		case RGB555:
-			_BUILD_SETUP(RGB555)
-			return (TRUE);
-
-		case BGR565:
-			_BUILD_SETUP(BGR565)
-			return (TRUE);
-
-		case BGR555:
-			_BUILD_SETUP(BGR555)
-			return (TRUE);
-
-		case GBR565:
-			_BUILD_SETUP(GBR565)
-			return (TRUE);
-
-		case GBR555:
-			_BUILD_SETUP(GBR555)
-			return (TRUE);
-
-		case RGB5551:
-			_BUILD_SETUP(RGB5551)
-			return (TRUE);
-
-		default:
-			break;
-	}
-
-	return (FALSE);
-}
-
-#endif

--- a/source/snes9x/globals.cpp
+++ b/source/snes9x/globals.cpp
@@ -4,7 +4,6 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
-
 #include "snes9x.h"
 #include "memmap.h"
 #include "dma.h"
@@ -73,31 +72,6 @@ SnesModel	M1SNES = { 1, 3, 2 };
 SnesModel	M2SNES = { 2, 4, 3 };
 SnesModel	*Model = &M1SNES;
 
-#ifdef GFX_MULTI_FORMAT
-uint32	RED_LOW_BIT_MASK           = RED_LOW_BIT_MASK_RGB565;
-uint32	GREEN_LOW_BIT_MASK         = GREEN_LOW_BIT_MASK_RGB565;
-uint32	BLUE_LOW_BIT_MASK          = BLUE_LOW_BIT_MASK_RGB565;
-uint32	RED_HI_BIT_MASK            = RED_HI_BIT_MASK_RGB565;
-uint32	GREEN_HI_BIT_MASK          = GREEN_HI_BIT_MASK_RGB565;
-uint32	BLUE_HI_BIT_MASK           = BLUE_HI_BIT_MASK_RGB565;
-uint32	MAX_RED                    = MAX_RED_RGB565;
-uint32	MAX_GREEN                  = MAX_GREEN_RGB565;
-uint32	MAX_BLUE                   = MAX_BLUE_RGB565;
-uint32	SPARE_RGB_BIT_MASK         = SPARE_RGB_BIT_MASK_RGB565;
-uint32	GREEN_HI_BIT               = (MAX_GREEN_RGB565 + 1) >> 1;
-uint32	RGB_LOW_BITS_MASK          = (RED_LOW_BIT_MASK_RGB565 | GREEN_LOW_BIT_MASK_RGB565 | BLUE_LOW_BIT_MASK_RGB565);
-uint32	RGB_HI_BITS_MASK           = (RED_HI_BIT_MASK_RGB565  | GREEN_HI_BIT_MASK_RGB565  | BLUE_HI_BIT_MASK_RGB565);
-uint32	RGB_HI_BITS_MASKx2         = (RED_HI_BIT_MASK_RGB565  | GREEN_HI_BIT_MASK_RGB565  | BLUE_HI_BIT_MASK_RGB565) << 1;
-uint32	RGB_REMOVE_LOW_BITS_MASK   = ~RGB_LOW_BITS_MASK;
-uint32	FIRST_COLOR_MASK           = FIRST_COLOR_MASK_RGB565;
-uint32	SECOND_COLOR_MASK          = SECOND_COLOR_MASK_RGB565;
-uint32	THIRD_COLOR_MASK           = THIRD_COLOR_MASK_RGB565;
-uint32	ALPHA_BITS_MASK            = ALPHA_BITS_MASK_RGB565;
-uint32	FIRST_THIRD_COLOR_MASK     = 0;
-uint32	TWO_LOW_BITS_MASK          = 0;
-uint32	HIGH_BITS_SHIFTED_TWO_MASK = 0;
-#endif
-
 uint16 SignExtend[2] =
 {
 	0x0000,
@@ -144,6 +118,8 @@ uint8 mul_brightness[16][32] =
 	{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 	  0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f }
 };
+
+uint8 brightness_cap[64];
 
 uint8 S9xOpLengthsM0X0[256] =
 {

--- a/source/snes9x/pixform.h
+++ b/source/snes9x/pixform.h
@@ -4,234 +4,114 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
-
 #ifndef _PIXFORM_H_
 #define _PIXFORM_H_
 
-#ifdef GFX_MULTI_FORMAT
-
-enum { RGB565, RGB555, BGR565, BGR555, GBR565, GBR555, RGB5551 };
-
-#define BUILD_PIXEL(R, G, B)					((*GFX.BuildPixel) (R, G, B))
-#define BUILD_PIXEL2(R, G, B)					((*GFX.BuildPixel2) (R, G, B))
-#define DECOMPOSE_PIXEL(PIX, R, G, B)			((*GFX.DecomposePixel) (PIX, R, G, B))
-
-extern uint32	MAX_RED;
-extern uint32	MAX_GREEN;
-extern uint32	MAX_BLUE;
-extern uint32	RED_LOW_BIT_MASK;
-extern uint32	GREEN_LOW_BIT_MASK;
-extern uint32	BLUE_LOW_BIT_MASK;
-extern uint32	RED_HI_BIT_MASK;
-extern uint32	GREEN_HI_BIT_MASK;
-extern uint32	BLUE_HI_BIT_MASK;
-extern uint32	FIRST_COLOR_MASK;
-extern uint32	SECOND_COLOR_MASK;
-extern uint32	THIRD_COLOR_MASK;
-extern uint32	ALPHA_BITS_MASK;
-extern uint32	GREEN_HI_BIT;
-extern uint32	RGB_LOW_BITS_MASK;
-extern uint32	RGB_HI_BITS_MASK;
-extern uint32	RGB_HI_BITS_MASKx2;
-extern uint32	RGB_REMOVE_LOW_BITS_MASK;
-extern uint32	FIRST_THIRD_COLOR_MASK;
-extern uint32	TWO_LOW_BITS_MASK;
-extern uint32	HIGH_BITS_SHIFTED_TWO_MASK;
-extern uint32	SPARE_RGB_BIT_MASK;
-
-#endif
-
 /* RGB565 format */
-#define BUILD_PIXEL_RGB565(R, G, B)				(((int) (R) << 11) | ((int) (G) << 6) | (int) (B))
-#define BUILD_PIXEL2_RGB565(R, G, B)			(((int) (R) << 11) | ((int) (G) << 5) | (int) (B))
-#define DECOMPOSE_PIXEL_RGB565(PIX, R, G, B)	{ (R) = (PIX) >> 11; (G) = ((PIX) >> 6) & 0x1f; (B) = (PIX) & 0x1f; }
-#define SPARE_RGB_BIT_MASK_RGB565				(1 << 5)
+#define BUILD_PIXEL_RGB565(R, G, B)  (((int)(R) << 11) | ((int)(G) << 6) | (((int)(G) & 0x10) << 1) | (int)(B))
+#define BUILD_PIXEL2_RGB565(R, G, B) (((int)(R) << 11) | ((int)(G) << 5) | (int)(B))
+#define DECOMPOSE_PIXEL_RGB565(PIX, R, G, B) \
+    {                                        \
+        (R) = (PIX) >> 11;                   \
+        (G) = ((PIX) >> 6) & 0x1f;           \
+        (B) = (PIX)&0x1f;                    \
+    }
+#define SPARE_RGB_BIT_MASK_RGB565 (1 << 5)
 
-#define MAX_RED_RGB565				31
-#define MAX_GREEN_RGB565			63
-#define MAX_BLUE_RGB565				31
-#define RED_LOW_BIT_MASK_RGB565		0x0800
-#define GREEN_LOW_BIT_MASK_RGB565	0x0020
-#define BLUE_LOW_BIT_MASK_RGB565	0x0001
-#define RED_HI_BIT_MASK_RGB565		0x8000
-#define GREEN_HI_BIT_MASK_RGB565	0x0400
-#define BLUE_HI_BIT_MASK_RGB565		0x0010
-#define FIRST_COLOR_MASK_RGB565		0xF800
-#define SECOND_COLOR_MASK_RGB565	0x07E0
-#define THIRD_COLOR_MASK_RGB565		0x001F
-#define ALPHA_BITS_MASK_RGB565		0x0000
+#define MAX_RED_RGB565            31
+#define MAX_GREEN_RGB565          63
+#define MAX_BLUE_RGB565           31
+#define RED_SHIFT_BITS_RGB565     11
+#define GREEN_SHIFT_BITS_RGB565   6
+#define RED_LOW_BIT_MASK_RGB565   0x0800
+#define GREEN_LOW_BIT_MASK_RGB565 0x0020
+#define BLUE_LOW_BIT_MASK_RGB565  0x0001
+#define RED_HI_BIT_MASK_RGB565    0x8000
+#define GREEN_HI_BIT_MASK_RGB565  0x0400
+#define BLUE_HI_BIT_MASK_RGB565   0x0010
+#define FIRST_COLOR_MASK_RGB565   0xF800
+#define SECOND_COLOR_MASK_RGB565  0x07E0
+#define THIRD_COLOR_MASK_RGB565   0x001F
+#define ALPHA_BITS_MASK_RGB565    0x0000
 
 /* RGB555 format */
-#define BUILD_PIXEL_RGB555(R, G, B)				(((int) (R) << 10) | ((int) (G) << 5) | (int) (B))
-#define BUILD_PIXEL2_RGB555(R, G, B)			(((int) (R) << 10) | ((int) (G) << 5) | (int) (B))
-#define DECOMPOSE_PIXEL_RGB555(PIX, R, G, B)	{ (R) = (PIX) >> 10; (G) = ((PIX) >> 5) & 0x1f; (B) = (PIX) & 0x1f; }
-#define SPARE_RGB_BIT_MASK_RGB555				(1 << 15)
+#define BUILD_PIXEL_RGB555(R, G, B)  (((int)(R) << 10) | ((int)(G) << 5) | (int)(B))
+#define BUILD_PIXEL2_RGB555(R, G, B) (((int)(R) << 10) | ((int)(G) << 5) | (int)(B))
+#define DECOMPOSE_PIXEL_RGB555(PIX, R, G, B) \
+    {                                        \
+        (R) = (PIX) >> 10;                   \
+        (G) = ((PIX) >> 5) & 0x1f;           \
+        (B) = (PIX)&0x1f;                    \
+    }
+#define SPARE_RGB_BIT_MASK_RGB555 (1 << 15)
 
-#define MAX_RED_RGB555				31
-#define MAX_GREEN_RGB555			31
-#define MAX_BLUE_RGB555				31
-#define RED_LOW_BIT_MASK_RGB555		0x0400
-#define GREEN_LOW_BIT_MASK_RGB555	0x0020
-#define BLUE_LOW_BIT_MASK_RGB555	0x0001
-#define RED_HI_BIT_MASK_RGB555		0x4000
-#define GREEN_HI_BIT_MASK_RGB555	0x0200
-#define BLUE_HI_BIT_MASK_RGB555		0x0010
-#define FIRST_COLOR_MASK_RGB555		0x7C00
-#define SECOND_COLOR_MASK_RGB555	0x03E0
-#define THIRD_COLOR_MASK_RGB555		0x001F
-#define ALPHA_BITS_MASK_RGB555		0x0000
+#define MAX_RED_RGB555            31
+#define MAX_GREEN_RGB555          31
+#define MAX_BLUE_RGB555           31
+#define RED_SHIFT_BITS_RGB555     10
+#define GREEN_SHIFT_BITS_RGB555   5
+#define RED_LOW_BIT_MASK_RGB555   0x0400
+#define GREEN_LOW_BIT_MASK_RGB555 0x0020
+#define BLUE_LOW_BIT_MASK_RGB555  0x0001
+#define RED_HI_BIT_MASK_RGB555    0x4000
+#define GREEN_HI_BIT_MASK_RGB555  0x0200
+#define BLUE_HI_BIT_MASK_RGB555   0x0010
+#define FIRST_COLOR_MASK_RGB555   0x7C00
+#define SECOND_COLOR_MASK_RGB555  0x03E0
+#define THIRD_COLOR_MASK_RGB555   0x001F
+#define ALPHA_BITS_MASK_RGB555    0x0000
 
-/* BGR565 format */
-#define BUILD_PIXEL_BGR565(R, G, B)				(((int) (B) << 11) | ((int) (G) << 6) | (int) (R))
-#define BUILD_PIXEL2_BGR565(R, G, B)			(((int) (B) << 11) | ((int) (G) << 5) | (int) (R))
-#define DECOMPOSE_PIXEL_BGR565(PIX, R, G, B)	{ (B) = (PIX) >> 11; (G) = ((PIX) >> 6) & 0x1f; (R) = (PIX) & 0x1f; }
-#define SPARE_RGB_BIT_MASK_BGR565				(1 << 5)
-
-#define MAX_RED_BGR565				31
-#define MAX_GREEN_BGR565			63
-#define MAX_BLUE_BGR565				31
-#define RED_LOW_BIT_MASK_BGR565		0x0001
-#define GREEN_LOW_BIT_MASK_BGR565	0x0040
-#define BLUE_LOW_BIT_MASK_BGR565	0x0800
-#define RED_HI_BIT_MASK_BGR565		0x0010
-#define GREEN_HI_BIT_MASK_BGR565	0x0400
-#define BLUE_HI_BIT_MASK_BGR565		0x8000
-#define FIRST_COLOR_MASK_BGR565		0xF800
-#define SECOND_COLOR_MASK_BGR565	0x07E0
-#define THIRD_COLOR_MASK_BGR565		0x001F
-#define ALPHA_BITS_MASK_BGR565		0x0000
-
-/* BGR555 format */
-#define BUILD_PIXEL_BGR555(R, G, B)				(((int) (B) << 10) | ((int) (G) << 5) | (int) (R))
-#define BUILD_PIXEL2_BGR555(R, G, B)			(((int) (B) << 10) | ((int) (G) << 5) | (int) (R))
-#define DECOMPOSE_PIXEL_BGR555(PIX, R, G, B)	{ (B) = (PIX) >> 10; (G) = ((PIX) >> 5) & 0x1f; (R) = (PIX) & 0x1f; }
-#define SPARE_RGB_BIT_MASK_BGR555				(1 << 15)
-
-#define MAX_RED_BGR555				31
-#define MAX_GREEN_BGR555			31
-#define MAX_BLUE_BGR555				31
-#define RED_LOW_BIT_MASK_BGR555		0x0001
-#define GREEN_LOW_BIT_MASK_BGR555	0x0020
-#define BLUE_LOW_BIT_MASK_BGR555	0x0400
-#define RED_HI_BIT_MASK_BGR555		0x0010
-#define GREEN_HI_BIT_MASK_BGR555	0x0200
-#define BLUE_HI_BIT_MASK_BGR555		0x4000
-#define FIRST_COLOR_MASK_BGR555		0x7C00
-#define SECOND_COLOR_MASK_BGR555	0x03E0
-#define THIRD_COLOR_MASK_BGR555		0x001F
-#define ALPHA_BITS_MASK_BGR555		0x0000
-
-/* GBR565 format */
-#define BUILD_PIXEL_GBR565(R, G, B)				(((int) (G) << 11) | ((int) (B) << 6) | (int) (R))
-#define BUILD_PIXEL2_GBR565(R, G, B)			(((int) (G) << 11) | ((int) (B) << 5) | (int) (R))
-#define DECOMPOSE_PIXEL_GBR565(PIX, R, G, B)	{ (G) = (PIX) >> 11; (B) = ((PIX) >> 6) & 0x1f; (R) = (PIX) & 0x1f; }
-#define SPARE_RGB_BIT_MASK_GBR565				(1 << 5)
-
-#define MAX_RED_GBR565				31
-#define MAX_GREEN_GBR565			31
-#define MAX_BLUE_GBR565				63
-#define RED_LOW_BIT_MASK_GBR565		0x0001
-#define GREEN_LOW_BIT_MASK_GBR565	0x0800
-#define BLUE_LOW_BIT_MASK_GBR565	0x0040
-#define RED_HI_BIT_MASK_GBR565		0x0010
-#define GREEN_HI_BIT_MASK_GBR565	0x8000
-#define BLUE_HI_BIT_MASK_GBR565		0x0400
-#define FIRST_COLOR_MASK_GBR565		0xF800
-#define SECOND_COLOR_MASK_GBR565	0x07E0
-#define THIRD_COLOR_MASK_GBR565		0x001F
-#define ALPHA_BITS_MASK_GBR565		0x0000
-
-/* GBR555 format */
-#define BUILD_PIXEL_GBR555(R, G, B)				(((int) (G) << 10) | ((int) (B) << 5) | (int) (R))
-#define BUILD_PIXEL2_GBR555(R, G, B)			(((int) (G) << 10) | ((int) (B) << 5) | (int) (R))
-#define DECOMPOSE_PIXEL_GBR555(PIX, R, G, B)	{ (G) = (PIX) >> 10; (B) = ((PIX) >> 5) & 0x1f; (R) = (PIX) & 0x1f; }
-#define SPARE_RGB_BIT_MASK_GBR555				(1 << 15)
-
-#define MAX_RED_GBR555				31
-#define MAX_GREEN_GBR555			31
-#define MAX_BLUE_GBR555				31
-#define RED_LOW_BIT_MASK_GBR555		0x0001
-#define GREEN_LOW_BIT_MASK_GBR555	0x0400
-#define BLUE_LOW_BIT_MASK_GBR555	0x0020
-#define RED_HI_BIT_MASK_GBR555		0x0010
-#define GREEN_HI_BIT_MASK_GBR555	0x4000
-#define BLUE_HI_BIT_MASK_GBR555		0x0200
-#define FIRST_COLOR_MASK_GBR555		0x7C00
-#define SECOND_COLOR_MASK_GBR555	0x03E0
-#define THIRD_COLOR_MASK_GBR555		0x001F
-#define ALPHA_BITS_MASK_GBR555		0x0000
-
-/* RGB5551 format */
-#define BUILD_PIXEL_RGB5551(R, G, B)			(((int) (R) << 11) | ((int) (G) << 6) | (int) ((B) << 1) | 1)
-#define BUILD_PIXEL2_RGB5551(R, G, B)			(((int) (R) << 11) | ((int) (G) << 6) | (int) ((B) << 1) | 1)
-#define DECOMPOSE_PIXEL_RGB5551(PIX, R, G, B)	{ (R) = (PIX) >> 11; (G) = ((PIX) >> 6) & 0x1f; (B) = ((PIX) >> 1) & 0x1f; }
-#define SPARE_RGB_BIT_MASK_RGB5551				(1)
-
-#define MAX_RED_RGB5551				31
-#define MAX_GREEN_RGB5551			31
-#define MAX_BLUE_RGB5551			31
-#define RED_LOW_BIT_MASK_RGB5551	0x0800
-#define GREEN_LOW_BIT_MASK_RGB5551	0x0040
-#define BLUE_LOW_BIT_MASK_RGB5551	0x0002
-#define RED_HI_BIT_MASK_RGB5551		0x8000
-#define GREEN_HI_BIT_MASK_RGB5551	0x0400
-#define BLUE_HI_BIT_MASK_RGB5551	0x0020
-#define FIRST_COLOR_MASK_RGB5551	0xf800
-#define SECOND_COLOR_MASK_RGB5551	0x07c0
-#define THIRD_COLOR_MASK_RGB5551	0x003e
-#define ALPHA_BITS_MASK_RGB5551		0x0001
-
-#ifndef GFX_MULTI_FORMAT
-
-#define CONCAT(X, Y)	X##Y
+#define CONCAT(X, Y) X##Y
 
 // C pre-processor needs a two stage macro define to enable it to concat
 // to macro names together to form the name of another macro.
-#define BUILD_PIXEL_D(F, R, G, B)			CONCAT(BUILD_PIXEL_,F) (R, G, B)
-#define BUILD_PIXEL2_D(F, R, G, B)			CONCAT(BUILD_PIXEL2_,F) (R, G, B)
-#define DECOMPOSE_PIXEL_D(F, PIX, R, G, B)	CONCAT(DECOMPOSE_PIXEL_,F) (PIX, R, G, B)
+#define BUILD_PIXEL_D(F, R, G, B)          CONCAT(BUILD_PIXEL_, F) (R, G, B)
+#define BUILD_PIXEL2_D(F, R, G, B)         CONCAT(BUILD_PIXEL2_, F) (R, G, B)
+#define DECOMPOSE_PIXEL_D(F, PIX, R, G, B) CONCAT(DECOMPOSE_PIXEL_, F) (PIX, R, G, B)
 
-#define BUILD_PIXEL(R, G, B)				BUILD_PIXEL_D(PIXEL_FORMAT, R, G, B)
-#define BUILD_PIXEL2(R, G, B)				BUILD_PIXEL2_D(PIXEL_FORMAT, R, G, B)
-#define DECOMPOSE_PIXEL(PIX, R, G, B)		DECOMPOSE_PIXEL_D(PIXEL_FORMAT, PIX, R, G, B)
+#define BUILD_PIXEL(R, G, B)               BUILD_PIXEL_D(PIXEL_FORMAT, R, G, B)
+#define BUILD_PIXEL2(R, G, B)              BUILD_PIXEL2_D(PIXEL_FORMAT, R, G, B)
+#define DECOMPOSE_PIXEL(PIX, R, G, B)      DECOMPOSE_PIXEL_D(PIXEL_FORMAT, PIX, R, G, B)
 
-#define MAX_RED_D(F)						CONCAT(MAX_RED_, F)
-#define MAX_GREEN_D(F)						CONCAT(MAX_GREEN_, F)
-#define MAX_BLUE_D(F)						CONCAT(MAX_BLUE_, F)
-#define RED_LOW_BIT_MASK_D(F)				CONCAT(RED_LOW_BIT_MASK_, F)
-#define GREEN_LOW_BIT_MASK_D(F)				CONCAT(GREEN_LOW_BIT_MASK_, F)
-#define BLUE_LOW_BIT_MASK_D(F)				CONCAT(BLUE_LOW_BIT_MASK_, F)
-#define RED_HI_BIT_MASK_D(F)				CONCAT(RED_HI_BIT_MASK_, F)
-#define GREEN_HI_BIT_MASK_D(F)				CONCAT(GREEN_HI_BIT_MASK_, F)
-#define BLUE_HI_BIT_MASK_D(F)				CONCAT(BLUE_HI_BIT_MASK_, F)
-#define FIRST_COLOR_MASK_D(F)				CONCAT(FIRST_COLOR_MASK_, F)
-#define SECOND_COLOR_MASK_D(F)				CONCAT(SECOND_COLOR_MASK_, F)
-#define THIRD_COLOR_MASK_D(F)				CONCAT(THIRD_COLOR_MASK_, F)
-#define ALPHA_BITS_MASK_D(F)				CONCAT(ALPHA_BITS_MASK_, F)
+#define MAX_RED_D(F)            CONCAT(MAX_RED_, F)
+#define MAX_GREEN_D(F)          CONCAT(MAX_GREEN_, F)
+#define MAX_BLUE_D(F)           CONCAT(MAX_BLUE_, F)
+#define RED_SHIFT_BITS_D(F)     CONCAT(RED_SHIFT_BITS_, F)
+#define GREEN_SHIFT_BITS_D(F)   CONCAT(GREEN_SHIFT_BITS_, F)
+#define RED_LOW_BIT_MASK_D(F)   CONCAT(RED_LOW_BIT_MASK_, F)
+#define GREEN_LOW_BIT_MASK_D(F) CONCAT(GREEN_LOW_BIT_MASK_, F)
+#define BLUE_LOW_BIT_MASK_D(F)  CONCAT(BLUE_LOW_BIT_MASK_, F)
+#define RED_HI_BIT_MASK_D(F)    CONCAT(RED_HI_BIT_MASK_, F)
+#define GREEN_HI_BIT_MASK_D(F)  CONCAT(GREEN_HI_BIT_MASK_, F)
+#define BLUE_HI_BIT_MASK_D(F)   CONCAT(BLUE_HI_BIT_MASK_, F)
+#define FIRST_COLOR_MASK_D(F)   CONCAT(FIRST_COLOR_MASK_, F)
+#define SECOND_COLOR_MASK_D(F)  CONCAT(SECOND_COLOR_MASK_, F)
+#define THIRD_COLOR_MASK_D(F)   CONCAT(THIRD_COLOR_MASK_, F)
+#define ALPHA_BITS_MASK_D(F)    CONCAT(ALPHA_BITS_MASK_, F)
 
-#define MAX_RED								MAX_RED_D(PIXEL_FORMAT)
-#define MAX_GREEN							MAX_GREEN_D(PIXEL_FORMAT)
-#define MAX_BLUE							MAX_BLUE_D(PIXEL_FORMAT)
-#define RED_LOW_BIT_MASK					RED_LOW_BIT_MASK_D(PIXEL_FORMAT)
-#define GREEN_LOW_BIT_MASK					GREEN_LOW_BIT_MASK_D(PIXEL_FORMAT)
-#define BLUE_LOW_BIT_MASK					BLUE_LOW_BIT_MASK_D(PIXEL_FORMAT)
-#define RED_HI_BIT_MASK						RED_HI_BIT_MASK_D(PIXEL_FORMAT)
-#define GREEN_HI_BIT_MASK					GREEN_HI_BIT_MASK_D(PIXEL_FORMAT)
-#define BLUE_HI_BIT_MASK					BLUE_HI_BIT_MASK_D(PIXEL_FORMAT)
-#define FIRST_COLOR_MASK					FIRST_COLOR_MASK_D(PIXEL_FORMAT)
-#define SECOND_COLOR_MASK					SECOND_COLOR_MASK_D(PIXEL_FORMAT)
-#define THIRD_COLOR_MASK					THIRD_COLOR_MASK_D(PIXEL_FORMAT)
-#define ALPHA_BITS_MASK						ALPHA_BITS_MASK_D(PIXEL_FORMAT)
+#define MAX_RED            MAX_RED_D(PIXEL_FORMAT)
+#define MAX_GREEN          MAX_GREEN_D(PIXEL_FORMAT)
+#define MAX_BLUE           MAX_BLUE_D(PIXEL_FORMAT)
+#define RED_SHIFT_BITS     RED_SHIFT_BITS_D(PIXEL_FORMAT)
+#define GREEN_SHIFT_BITS   GREEN_SHIFT_BITS_D(PIXEL_FORMAT)
+#define RED_LOW_BIT_MASK   RED_LOW_BIT_MASK_D(PIXEL_FORMAT)
+#define GREEN_LOW_BIT_MASK GREEN_LOW_BIT_MASK_D(PIXEL_FORMAT)
+#define BLUE_LOW_BIT_MASK  BLUE_LOW_BIT_MASK_D(PIXEL_FORMAT)
+#define RED_HI_BIT_MASK    RED_HI_BIT_MASK_D(PIXEL_FORMAT)
+#define GREEN_HI_BIT_MASK  GREEN_HI_BIT_MASK_D(PIXEL_FORMAT)
+#define BLUE_HI_BIT_MASK   BLUE_HI_BIT_MASK_D(PIXEL_FORMAT)
+#define FIRST_COLOR_MASK   FIRST_COLOR_MASK_D(PIXEL_FORMAT)
+#define SECOND_COLOR_MASK  SECOND_COLOR_MASK_D(PIXEL_FORMAT)
+#define THIRD_COLOR_MASK   THIRD_COLOR_MASK_D(PIXEL_FORMAT)
+#define ALPHA_BITS_MASK    ALPHA_BITS_MASK_D(PIXEL_FORMAT)
 
-#define GREEN_HI_BIT						((MAX_GREEN + 1) >> 1)
-#define RGB_LOW_BITS_MASK					(RED_LOW_BIT_MASK | GREEN_LOW_BIT_MASK | BLUE_LOW_BIT_MASK)
-#define RGB_HI_BITS_MASK					(RED_HI_BIT_MASK | GREEN_HI_BIT_MASK | BLUE_HI_BIT_MASK)
-#define RGB_HI_BITS_MASKx2					((RED_HI_BIT_MASK | GREEN_HI_BIT_MASK | BLUE_HI_BIT_MASK) << 1)
-#define RGB_REMOVE_LOW_BITS_MASK			(~RGB_LOW_BITS_MASK)
-#define FIRST_THIRD_COLOR_MASK				(FIRST_COLOR_MASK | THIRD_COLOR_MASK)
-#define TWO_LOW_BITS_MASK					(RGB_LOW_BITS_MASK | (RGB_LOW_BITS_MASK << 1))
-#define HIGH_BITS_SHIFTED_TWO_MASK			(((FIRST_COLOR_MASK | SECOND_COLOR_MASK | THIRD_COLOR_MASK) & ~TWO_LOW_BITS_MASK ) >> 2)
+#define GREEN_HI_BIT               ((MAX_GREEN + 1) >> 1)
+#define RGB_LOW_BITS_MASK          (RED_LOW_BIT_MASK | GREEN_LOW_BIT_MASK | BLUE_LOW_BIT_MASK)
+#define RGB_HI_BITS_MASK           (RED_HI_BIT_MASK | GREEN_HI_BIT_MASK | BLUE_HI_BIT_MASK)
+#define RGB_HI_BITS_MASKx2         ((RED_HI_BIT_MASK | GREEN_HI_BIT_MASK | BLUE_HI_BIT_MASK) << 1)
+#define RGB_REMOVE_LOW_BITS_MASK   (~RGB_LOW_BITS_MASK)
+#define FIRST_THIRD_COLOR_MASK     (FIRST_COLOR_MASK | THIRD_COLOR_MASK)
+#define TWO_LOW_BITS_MASK          (RGB_LOW_BITS_MASK | (RGB_LOW_BITS_MASK << 1))
+#define HIGH_BITS_SHIFTED_TWO_MASK (((FIRST_COLOR_MASK | SECOND_COLOR_MASK | THIRD_COLOR_MASK) & ~TWO_LOW_BITS_MASK) >> 2)
 
-#endif
-
-#endif
+#endif // _PIXFORM_H_

--- a/source/snes9x/port.h
+++ b/source/snes9x/port.h
@@ -26,8 +26,6 @@
 #include <windows.h>
 #endif
 
-#define GFX_MULTI_FORMAT
-
 #ifdef __WIN32__
 //#define RIGHTSHIFT_IS_SAR
 #define RIGHTSHIFT_int8_IS_SAR
@@ -37,7 +35,6 @@
 #endif
 
 #ifdef __MACOSX__
-#undef GFX_MULTI_FORMAT
 #define PIXEL_FORMAT RGB555
 #endif
 

--- a/source/snes9x/ppu.cpp
+++ b/source/snes9x/ppu.cpp
@@ -4,7 +4,6 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
-
 #include "snes9x.h"
 #include "memmap.h"
 #include "dma.h"
@@ -259,6 +258,14 @@ void S9xUpdateHVTimerPosition (void)
 void S9xFixColourBrightness (void)
 {
 	IPPU.XB = mul_brightness[PPU.Brightness];
+
+	for (int i = 0; i < 64; i++)
+	{
+		if (i > IPPU.XB[0x1f])
+			brightness_cap[i] = IPPU.XB[0x1f];
+		else
+			brightness_cap[i] = i;
+	}
 
 	for (int i = 0; i < 256; i++)
 	{

--- a/source/snes9x/ppu.h
+++ b/source/snes9x/ppu.h
@@ -4,7 +4,6 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
-
 #ifndef _PPU_H_
 #define _PPU_H_
 
@@ -239,6 +238,7 @@ extern SnesModel	M2SNES;
 #define MAX_5C78_VERSION	0x03
 #define MAX_5A22_VERSION	0x02
 
+void S9xUpdateScreen (void);
 static inline void FLUSH_REDRAW (void)
 {
 	if (IPPU.PreviousLine != IPPU.CurrentLine)

--- a/source/snes9x/tile.cpp
+++ b/source/snes9x/tile.cpp
@@ -22,7 +22,6 @@ static uint32	pixbit[8][16];
 static uint8	hrbit_odd[256];
 static uint8	hrbit_even[256];
 
-
 void S9xInitTileRenderer (void)
 {
 	register int	i;
@@ -402,6 +401,14 @@ void S9xSelectTileRenderers (int BGMode, bool8 sub, bool8 obj)
 			if (Memory.FillRAM[0x2130] & 2)
 				i++;
 		}
+		if (IPPU.MaxBrightness != 0xf)
+		{
+			if (i == 1)
+				i = 7;
+			else if (i == 3)
+				i = 8;
+		}
+
 	}
 
 	GFX.DrawTileMath        = DT[i];
@@ -581,14 +588,9 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 		bp = pCache + BPSTART; \
 		for (l = LineCount; l > 0; l--, bp += 8 * PITCH, Offset += GFX.PPL) \
 		{ \
-			DRAW_PIXEL(0, Pix = bp[0]); \
-			DRAW_PIXEL(1, Pix = bp[1]); \
-			DRAW_PIXEL(2, Pix = bp[2]); \
-			DRAW_PIXEL(3, Pix = bp[3]); \
-			DRAW_PIXEL(4, Pix = bp[4]); \
-			DRAW_PIXEL(5, Pix = bp[5]); \
-			DRAW_PIXEL(6, Pix = bp[6]); \
-			DRAW_PIXEL(7, Pix = bp[7]); \
+			for (int x = 0; x < 8; x++) { \
+				DRAW_PIXEL(x, Pix = bp[x]); \
+			} \
 		} \
 	} \
 	else \
@@ -597,14 +599,9 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 		bp = pCache + BPSTART; \
 		for (l = LineCount; l > 0; l--, bp += 8 * PITCH, Offset += GFX.PPL) \
 		{ \
-			DRAW_PIXEL(0, Pix = bp[7]); \
-			DRAW_PIXEL(1, Pix = bp[6]); \
-			DRAW_PIXEL(2, Pix = bp[5]); \
-			DRAW_PIXEL(3, Pix = bp[4]); \
-			DRAW_PIXEL(4, Pix = bp[3]); \
-			DRAW_PIXEL(5, Pix = bp[2]); \
-			DRAW_PIXEL(6, Pix = bp[1]); \
-			DRAW_PIXEL(7, Pix = bp[0]); \
+			for (int x = 0; x < 8; x++) { \
+				DRAW_PIXEL(x, Pix = bp[7 - x]); \
+			} \
 		} \
 	} \
 	else \
@@ -613,14 +610,9 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 		bp = pCache + 56 - BPSTART; \
 		for (l = LineCount; l > 0; l--, bp -= 8 * PITCH, Offset += GFX.PPL) \
 		{ \
-			DRAW_PIXEL(0, Pix = bp[0]); \
-			DRAW_PIXEL(1, Pix = bp[1]); \
-			DRAW_PIXEL(2, Pix = bp[2]); \
-			DRAW_PIXEL(3, Pix = bp[3]); \
-			DRAW_PIXEL(4, Pix = bp[4]); \
-			DRAW_PIXEL(5, Pix = bp[5]); \
-			DRAW_PIXEL(6, Pix = bp[6]); \
-			DRAW_PIXEL(7, Pix = bp[7]); \
+			for (int x = 0; x < 8; x++) { \
+				DRAW_PIXEL(x, Pix = bp[x]); \
+			} \
 		} \
 	} \
 	else \
@@ -628,14 +620,9 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 		bp = pCache + 56 - BPSTART; \
 		for (l = LineCount; l > 0; l--, bp -= 8 * PITCH, Offset += GFX.PPL) \
 		{ \
-			DRAW_PIXEL(0, Pix = bp[7]); \
-			DRAW_PIXEL(1, Pix = bp[6]); \
-			DRAW_PIXEL(2, Pix = bp[5]); \
-			DRAW_PIXEL(3, Pix = bp[4]); \
-			DRAW_PIXEL(4, Pix = bp[3]); \
-			DRAW_PIXEL(5, Pix = bp[2]); \
-			DRAW_PIXEL(6, Pix = bp[1]); \
-			DRAW_PIXEL(7, Pix = bp[0]); \
+			for (int x = 0; x < 8; x++) { \
+				DRAW_PIXEL(x, Pix = bp[7 - x]); \
+			} \
 		} \
 	}
 
@@ -1290,6 +1277,13 @@ static void MAKENAME(NAME1, Add_, NAME2) (ARGS)
 #undef MATH
 }
 
+static void MAKENAME(NAME1, Add_Brightness_, NAME2) (ARGS)
+{
+#define MATH(A, B, C)	REGMATH(ADD_BRIGHTNESS, A, B, C)
+	DRAW_TILE();
+#undef MATH
+}
+
 static void MAKENAME(NAME1, AddF1_2_, NAME2) (ARGS)
 {
 #define MATH(A, B, C)	MATHF1_2(ADD, A, B, C)
@@ -1300,6 +1294,13 @@ static void MAKENAME(NAME1, AddF1_2_, NAME2) (ARGS)
 static void MAKENAME(NAME1, AddS1_2_, NAME2) (ARGS)
 {
 #define MATH(A, B, C)	MATHS1_2(ADD, A, B, C)
+	DRAW_TILE();
+#undef MATH
+}
+
+static void MAKENAME(NAME1, AddS1_2_Brightness_, NAME2) (ARGS)
+{
+#define MATH(A, B, C)	MATHS1_2(ADD_BRIGHTNESS, A, B, C)
 	DRAW_TILE();
 #undef MATH
 }
@@ -1325,7 +1326,7 @@ static void MAKENAME(NAME1, SubS1_2_, NAME2) (ARGS)
 #undef MATH
 }
 
-static void (*MAKENAME(Renderers_, NAME1, NAME2)[7]) (ARGS) =
+static void (*MAKENAME(Renderers_, NAME1, NAME2)[9]) (ARGS) =
 {
 	MAKENAME(NAME1, _, NAME2),
 	MAKENAME(NAME1, Add_, NAME2),
@@ -1333,7 +1334,9 @@ static void (*MAKENAME(Renderers_, NAME1, NAME2)[7]) (ARGS) =
 	MAKENAME(NAME1, AddS1_2_, NAME2),
 	MAKENAME(NAME1, Sub_, NAME2),
 	MAKENAME(NAME1, SubF1_2_, NAME2),
-	MAKENAME(NAME1, SubS1_2_, NAME2)
+	MAKENAME(NAME1, SubS1_2_, NAME2),
+	MAKENAME(NAME1, Add_Brightness_, NAME2),
+	MAKENAME(NAME1, AddS1_2_Brightness_, NAME2)
 };
 
 #undef MAKENAME


### PR DESCRIPTION
- Fix PPU blending with unoptimized change.
- Use a lookup table. A little faster.
- Fix color add for non-GFX_MULTI_FORMAT.
- Make blending work with RGB555.
- Remove most of GFX_MULTI_FORMAT.
- Proper 16-bit color conversion
- Use for loops for DRAW_TILE. 3-4% speed benefit.
- Select brightness function in tile renderer.