### PR TITLE
Add a toggle to hide/show the "Save SRAM" button in the save menu UI

### DIFF
--- a/source/gui/gui_savebrowser.cpp
+++ b/source/gui/gui_savebrowser.cpp
@@ -323,21 +323,27 @@ void GuiSaveBrowser::Update(GuiTrigger * t)
 	{
 		if(listOffset+i < 0 && action == 1)
 		{
+			
 			saveDate[0]->SetText(NULL);
-			saveDate[1]->SetText(NULL);
 			saveTime[0]->SetText("New");
-			saveTime[1]->SetText("New");
-			saveType[0]->SetText("SRAM");
-			saveType[1]->SetText("Snapshot");
+			saveType[0]->SetText("Snapshot");
 			savePreviewImg[0]->SetImage(gameSaveBlank);
-			savePreviewImg[1]->SetImage(gameSaveBlank);
 			saveBtn[0]->SetVisible(true);
-			saveBtn[1]->SetVisible(true);
 
 			if(saveBtn[0]->GetState() == STATE_DISABLED)
 				saveBtn[0]->SetState(STATE_DEFAULT);
-			if(saveBtn[1]->GetState() == STATE_DISABLED)
-				saveBtn[1]->SetState(STATE_DEFAULT);
+			
+			if (GCSettings.HideSRAMSaving == 0)
+			{
+				saveDate[1]->SetText(NULL);
+				saveTime[1]->SetText("New");
+				saveType[1]->SetText("SRAM");
+				savePreviewImg[1]->SetImage(gameSaveBlank);
+				saveBtn[1]->SetVisible(true);
+
+				if(saveBtn[1]->GetState() == STATE_DISABLED)
+					saveBtn[1]->SetState(STATE_DEFAULT);
+			}
 		}
 		else if(listOffset+i < saves->length)
 		{

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -2008,20 +2008,7 @@ static int MenuGameSaves(int action)
 			}
 			else // save
 			{
-				if(ret == -2) // new SRAM
-				{
-					for(i=1; i < 100; i++)
-						if(saves.files[FILE_SRAM][i] == 0)
-							break;
-
-					if(i < 100)
-					{
-						MakeFilePath(filepath, FILE_SRAM, Memory.ROMFilename, i);
-						SaveSRAM(filepath, NOTSILENT);
-						menu = MENU_GAME_SAVE;
-					}
-				}
-				else if(ret == -1) // new Snapshot
+				if(ret == -2) // new Snapshot
 				{
 					for(i=1; i < 100; i++)
 						if(saves.files[FILE_SNAPSHOT][i] == 0)
@@ -2031,6 +2018,19 @@ static int MenuGameSaves(int action)
 					{
 						MakeFilePath(filepath, FILE_SNAPSHOT, Memory.ROMFilename, i);
 						SaveSnapshot (filepath, NOTSILENT);
+						menu = MENU_GAME_SAVE;
+					}
+				}
+				else if(ret == -1 && GCSettings.HideSRAMSaving == 0) // new SRAM
+				{
+					for(i=1; i < 100; i++)
+						if(saves.files[FILE_SRAM][i] == 0)
+							break;
+
+					if(i < 100)
+					{
+						MakeFilePath(filepath, FILE_SRAM, Memory.ROMFilename, i);
+						SaveSRAM(filepath, NOTSILENT);
 						menu = MENU_GAME_SAVE;
 					}
 				}
@@ -4231,6 +4231,7 @@ static int MenuSettingsMenu()
 	sprintf(options.name[i++], "Display Virtual Memory");
 	sprintf(options.name[i++], "Language");
 	sprintf(options.name[i++], "Preview Image");
+	sprintf(options.name[i++], "Hide SRAM Saving");
 	options.length = i;
 
 	for(i=0; i < options.length; i++)
@@ -4319,6 +4320,9 @@ static int MenuSettingsMenu()
 				if(GCSettings.PreviewImage > 2)
 					GCSettings.PreviewImage = 0;
 				break;
+			case 7:
+				GCSettings.HideSRAMSaving ^= 1;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -4366,6 +4370,11 @@ static int MenuSettingsMenu()
 				sprintf (options.value[4], "Enabled");
 			else
 				sprintf (options.value[4], "Disabled");
+
+			if (GCSettings.HideSRAMSaving == 1)
+				sprintf (options.value[7], "On");
+			else
+				sprintf (options.value[7], "Off");
 
 			switch(GCSettings.language)
 			{

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -168,6 +168,7 @@ preparePrefsData ()
 	createXMLSetting("DisplayVM", "Display Virtual Memory", toStr(GCSettings.DisplayVM));
 	createXMLSetting("language", "Language", toStr(GCSettings.language));
 	createXMLSetting("PreviewImage", "Preview Image", toStr(GCSettings.PreviewImage));
+	createXMLSetting("HideSRAMSaving", "Hide SRAM Saving", toStr(GCSettings.HideSRAMSaving));
 	
 	createXMLSection("Controller", "Controller Settings");
 
@@ -361,6 +362,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.DisplayVM, "DisplayVM");
 			loadXMLSetting(&GCSettings.language, "language");
 			loadXMLSetting(&GCSettings.PreviewImage, "PreviewImage");
+			loadXMLSetting(&GCSettings.HideSRAMSaving, "HideSRAMSaving");
 
 			// Controller Settings
 
@@ -468,6 +470,7 @@ DefaultSettings ()
 	GCSettings.SFXVolume = 40;
 	GCSettings.DisplayVM = 0; // Disabled
 	GCSettings.PreviewImage = 0;
+	GCSettings.HideSRAMSaving = 0;
 	
 #ifdef HW_RVL
 	GCSettings.language = CONF_GetLanguage();

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -59,7 +59,6 @@ int ResetRequested = 0;
 int ExitRequested = 0;
 bool isWiiVC = false;
 char appPath[1024] = { 0 };
-static int currentMode;
 bool firstRun = true;
 
 extern "C" {
@@ -536,7 +535,6 @@ int main(int argc, char *argv[])
 
 		CheckVideo = 2;		// force video update
 		prevRenderedFrameCount = IPPU.RenderedFramesCount;
-		currentMode = GCSettings.render;
 
 		while(1) // emulation loop
 		{

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -360,22 +360,22 @@ extern "C" {
 }
 
 void InitializeSnes9x() {
-	S9xUnmapAllControls ();
-	SetDefaultButtonMap ();
+	S9xUnmapAllControls();
+	SetDefaultButtonMap();
 
 	// Allocate SNES Memory
-	if (!Memory.Init ())
+	if (!Memory.Init())
 		ExitApp();
 
 	// Allocate APU
-	if (!S9xInitAPU ())
+	if (!S9xInitAPU())
 		ExitApp();
 
-	S9xInitSound (64, 0); // Initialise Sound System
+	S9xInitSound(64, 0); // Initialise Sound System
 
 	// Initialise Graphics
-	setGFX ();
-	if (!S9xGraphicsInit ())
+	setGFX();
+	if (!S9xGraphicsInit())
 		ExitApp();
 
 	AllocGfxMem();
@@ -406,10 +406,10 @@ int main(int argc, char *argv[])
 	USBGeckoOutput();
 	__exception_setreload(8);
 
-	DefaultSettings (); // Set defaults
+	DefaultSettings(); // Set defaults
 	InitGCVideo(); // Initialise video
 	InitializeSnes9x();
-	ResetVideo_Menu (); // change to menu video mode
+	ResetVideo_Menu(); // change to menu video mode
 	
 	#ifdef HW_RVL
 	// Wii Power/Reset buttons
@@ -427,7 +427,7 @@ int main(int argc, char *argv[])
 	DI_Init();
 	USBStorage_Initialize();
 	#else
-	DVD_Init (); // Initialize DVD subsystem (GameCube only)
+	DVD_Init(); // Initialize DVD subsystem (GameCube only)
 	#endif
 	
 	SetupPads();
@@ -486,10 +486,7 @@ int main(int argc, char *argv[])
 
 			SwitchAudioMode(1);
 
-			if(SNESROMSize == 0)
-				MainMenu(MENU_GAMESELECTION);
-			else
-				MainMenu(MENU_GAME);
+			SNESROMSize == 0 ? MainMenu(MENU_GAMESELECTION) : MainMenu(MENU_GAME);
 		}
 
 #ifdef HW_RVL
@@ -506,16 +503,13 @@ int main(int argc, char *argv[])
 				case 3: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
 			}
 
-			if (GCSettings.sfxOverclock > 0)
-			S9xResetSuperFX();
-			else
-			S9xReset();
+			GCSettings.sfxOverclock > 0 ? S9xResetSuperFX() : S9xReset();
 
 			switch (GCSettings.Interpolation)
 			{
-			case 0: Settings.InterpolationMethod = DSP_INTERPOLATION_GAUSSIAN; break;
-			case 1: Settings.InterpolationMethod = DSP_INTERPOLATION_LINEAR; break;
-			case 2: Settings.InterpolationMethod = DSP_INTERPOLATION_NONE; break;
+				case 0: Settings.InterpolationMethod = DSP_INTERPOLATION_GAUSSIAN; break;
+				case 1: Settings.InterpolationMethod = DSP_INTERPOLATION_LINEAR; break;
+				case 2: Settings.InterpolationMethod = DSP_INTERPOLATION_NONE; break;
 			}
 		}
 
@@ -529,16 +523,16 @@ int main(int argc, char *argv[])
 		Settings.SuperScopeMaster = (GCSettings.Controller == CTRL_SCOPE ? true : false);
 		Settings.MouseMaster = (GCSettings.Controller == CTRL_MOUSE ? true : false);
 		Settings.JustifierMaster = (GCSettings.Controller == CTRL_JUST ? true : false);
-		SetControllers ();
+		SetControllers();
 
 		// stop checking if devices were removed/inserted
 		// since we're starting emulation again
 		HaltDeviceThread();
 
-		AudioStart ();
+		AudioStart();
 
 		FrameTimer = 0;
-		setFrameTimerMethod (); // set frametimer method every time a ROM is loaded
+		setFrameTimerMethod(); // set frametimer method every time a ROM is loaded
 
 		CheckVideo = 2;		// force video update
 		prevRenderedFrameCount = IPPU.RenderedFramesCount;
@@ -546,12 +540,12 @@ int main(int argc, char *argv[])
 
 		while(1) // emulation loop
 		{
-			S9xMainLoop ();
-			ReportButtons ();
+			S9xMainLoop();
+			ReportButtons();
 
-			if(ResetRequested)
+			if (ResetRequested)
 			{
-				S9xSoftReset (); // reset game
+				S9xSoftReset(); // reset game
 				ResetRequested = 0;
 			}
 			if (ConfigRequested)

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -112,7 +112,7 @@ struct SGCSettings{
 	char	CoverFolder[MAXPATHLEN]; 	// Path to cover files
 	char	ArtworkFolder[MAXPATHLEN]; 	// Path to artwork files
 	char 	ImageFolder[MAXPATHLEN]; 	// Saved image folder path 
-
+	int		HideSRAMSaving;
 	int		AutoloadGame;
 
 	char	smbip[80];


### PR DESCRIPTION
This is to address an annoyance of mine in the UI - the save menu defaults to "Save SRAM" upon entering it, and in order to save a state the user must always navigate one to the right every time. This can become problematic when quickly accessing the menu to make new states, inadvertently creating SRAM states if their inputs are too quick for the UI.

Personally, in all my years using the GX emulators, I've never once needed to make an SRAM state. I've loaded a few acquired from the internet on rare occasions, but 100% of all the SRAM states I've ever made were on accident from the situation described above. It's a nitpick for sure, but very annoying.

The toggle is off by default (Save SRAM is shown). I also made some minor formatting updates and removed a seemingly unused variable in snes9xgx.cpp.

It's up to you if you want to merge this in, as maybe I'm just crazy in wanting this feature haha. I'll just keep it around for personal builds if not.