### PR TITLE
Fix of SNES CPU overclock setting (fixes Wild Snake) (Tanooki16)

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -546,9 +546,14 @@ DefaultSettings ()
 	Settings.FrameTimeNTSC = 16667;
 
 	GCSettings.sfxOverclock = 0;
-	/* Initialize SuperFX CPU to normal speed by default */
+	/* Initialize SuperFX to normal speed by default */
 	Settings.SuperFXSpeedPerLine = 0.417 * 10.5e6;
-	GCSettings.cpuOverclock = 0; // Disabled by default
+
+	GCSettings.cpuOverclock = 0;
+	/* Initialize CPU to normal speed by default */
+	Settings.OneClockCycle = 6;
+	Settings.OneSlowClockCycle = 8;
+	Settings.TwoClockCycles = 12;
 
 	GCSettings.TurboModeEnabled = 1; // Enabled by default
 	GCSettings.TurboModeButton = 0; // Default is Right Analog Stick (0)


### PR DESCRIPTION
See here:
https://gbatemp.net/threads/snes9x-rx-a-new-fork.527131/post-9885973
https://gbatemp.net/threads/snes9xgx-mushroom.558500/post-9883617

This fixes the game Wild Snake when using the CPU overclock feature.