### PR TITLE
Re-add HiResolution, SpriteLimit, cpuOverclock variables to snes9xgx.h (fixes compiling)

### DIFF
--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -141,6 +141,10 @@ struct SGCSettings{
 	int		PreviewImage;
 
 	int		sfxOverclock;
+	
+	int		HiResolution;
+	int		SpriteLimit;
+	int		cpuOverclock;
 
 	int		ReverseStereo;
 	int		Interpolation;


### PR DESCRIPTION
By any reason you accidentally deleted the declaration of the following variables "HiResolution", "SpriteLimit", "cpuOverclock" on SGCSettings (on snes9xgx.h file), causing that when trying to compile it got stuck at menu.cpp.

This small modification fixes that.