### PR TITLE
Add controller options for Mouse in port 2 and Mouse in both ports

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -717,7 +717,7 @@ static void decodepad (int chan, int emuChan)
 		S9xReportPointer(offset, (u16) cursor_x[0], (u16) cursor_y[0]);
 	}
 	/*** Mouse ***/
-	else if (Settings.MouseMaster && emuChan == 0)
+	else if (Settings.MouseMaster && emuChan < 2)
 	{
 		// buttons
 		offset = 0x60 + (2 * emuChan);
@@ -975,8 +975,21 @@ void SetControllers()
 	}
 	else if (Settings.MouseMaster == true)
 	{
-		S9xSetController (0, CTL_MOUSE, 0, 0, 0, 0);
-		S9xSetController (1, CTL_JOYPAD, 1, 0, 0, 0);
+		if (GCSettings.Controller == CTRL_MOUSE)
+		{
+			S9xSetController (0, CTL_MOUSE, 0, 0, 0, 0);
+			S9xSetController (1, CTL_JOYPAD, 1, 0, 0, 0);
+		}
+		else if (GCSettings.Controller == CTRL_MOUSE_PORT2)
+		{
+			S9xSetController (0, CTL_JOYPAD, 0, 0, 0, 0);
+			S9xSetController (1, CTL_MOUSE, 1, 0, 0, 0);
+		}
+		else if (GCSettings.Controller == CTRL_MOUSE_BOTH_PORTS)
+		{
+			S9xSetController (0, CTL_MOUSE, 0, 0, 0, 0);
+			S9xSetController (1, CTL_MOUSE, 1, 0, 0, 0);
+		}	
 	}
 	else if (Settings.JustifierMaster == true)
 	{

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -1180,8 +1180,8 @@ static void ControllerWindowUpdate(void * ptr, int dir)
 		GCSettings.Controller += dir;
 
 		if(GCSettings.Controller > CTRL_PAD4)
-			GCSettings.Controller = CTRL_MOUSE;
-		if(GCSettings.Controller < CTRL_MOUSE)
+			GCSettings.Controller = CTRL_SCOPE;
+		if(GCSettings.Controller < CTRL_SCOPE)
 			GCSettings.Controller = CTRL_PAD4;
 
 		settingText->SetText(ctrlName[GCSettings.Controller]);

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -436,7 +436,7 @@ void FixInvalidSettings()
 		GCSettings.SFXVolume = 40;
 	if(GCSettings.language < 0 || GCSettings.language >= LANG_LENGTH)
 		GCSettings.language = LANG_ENGLISH;
-	if(GCSettings.Controller > CTRL_PAD4 || GCSettings.Controller < CTRL_MOUSE)
+	if(GCSettings.Controller > CTRL_PAD4 || GCSettings.Controller < CTRL_SCOPE)
 		GCSettings.Controller = CTRL_PAD2;
 	if(!(GCSettings.render >= 0 && GCSettings.render < 5))
 		GCSettings.render = 4;

--- a/source/snes9xrx.cpp
+++ b/source/snes9xrx.cpp
@@ -551,7 +551,7 @@ int main(int argc, char *argv[])
 		Settings.MaxSpriteTilesPerLine = (GCSettings.SpriteLimit ? 34 : 128);
 		Settings.MultiPlayer5Master = (GCSettings.Controller == CTRL_PAD4 ? true : false);
 		Settings.SuperScopeMaster = (GCSettings.Controller == CTRL_SCOPE ? true : false);
-		Settings.MouseMaster = (GCSettings.Controller == CTRL_MOUSE ? true : false);
+		Settings.MouseMaster = (GCSettings.Controller == CTRL_MOUSE || GCSettings.Controller == CTRL_MOUSE_PORT2 || GCSettings.Controller == CTRL_MOUSE_BOTH_PORTS);
 		Settings.JustifierMaster = (GCSettings.Controller == CTRL_JUST ? true : false);
 		SetControllers();
 

--- a/source/snes9xrx.h
+++ b/source/snes9xrx.h
@@ -51,16 +51,27 @@ enum {
 enum
 {
 	CTRL_PAD,
-	CTRL_MOUSE,
 	CTRL_SCOPE,
 	CTRL_JUST,
+	CTRL_MOUSE,
+	CTRL_MOUSE_PORT2,
+	CTRL_MOUSE_BOTH_PORTS,
 	CTRL_PAD2,
 	CTRL_PAD4,
 	CTRL_LENGTH
 };
 
-const char ctrlName[6][24] =
-{ "SNES Controller", "SNES Mouse", "Super Scope", "Justifier", "SNES Controllers (2)", "SNES Controllers (4)" };
+const char ctrlName[8][24] =
+{ 
+	"SNES Controller", 
+	"Super Scope", 
+	"Justifier", 
+	"SNES Mouse (Port 1)", 
+	"SNES Mouse (Port 2)", 
+	"SNES Mouse (Both Ports)",
+	"SNES Controllers (2)", 
+	"SNES Controllers (4)"
+};
 
 enum {
 	TURBO_BUTTON_RSTICK = 0,


### PR DESCRIPTION
(Will be making a PR for this into GX shortly)

This adds new controller configuration options for the SNES Mouse. The controller selection screen now features:

- "SNES Mouse (Port 1)" - this is the renamed "SNES Mouse" configuration that originally existed in Snes9xGX. Mouse in port 1, gamepad in port 2. Most Mouse games use this configuration.
- "SNES Mouse (Port 2)" - a newly added option where the Mouse is in port 2, and a gamepad in port 1. Certain games and romhacks like Wolfenstein 3D and Jurassic Park use the Mouse in port 2 exclusively, while simultaneously having gamepad functionality on port 1. 
- "SNES Mouse (Both Ports)" - another new option where the Mouse is added to both ports. This allows games  that support simultaneous Mouse inputs like T2: The Arcade Game and Revolution X to function with them. Mouse games that exclusively use port 1 or 2 will still have Mouse functionality under this configuration, but gamepad support on the non-mouse port will obviously not be available.