### PR TITLE
Add new .cht file support into RX

### DIFF
--- a/source/gui/gui_optionbrowser.cpp
+++ b/source/gui/gui_optionbrowser.cpp
@@ -81,6 +81,7 @@ GuiOptionBrowser::GuiOptionBrowser(int w, int h, OptionList * l)
 		optionTxt[i] = new GuiText(NULL, 20, (GXColor){0, 0, 0, 0xff});
 		optionTxt[i]->SetAlignment(ALIGN_LEFT, ALIGN_MIDDLE);
 		optionTxt[i]->SetPosition(8,0);
+		optionTxt[i]->SetMaxWidth(235);
 
 		optionVal[i] = new GuiText(NULL, 20, (GXColor){0, 0, 0, 0xff});
 		optionVal[i]->SetAlignment(ALIGN_LEFT, ALIGN_MIDDLE);
@@ -314,6 +315,11 @@ void GuiOptionBrowser::Update(GuiTrigger * t)
 
 		if(optionBtn[i]->GetState() == STATE_SELECTED)
 			selectedItem = i;
+
+		if(selectedItem == i)
+			optionTxt[i]->SetScroll(SCROLL_HORIZONTAL);
+		else
+			optionTxt[i]->SetScroll(SCROLL_NONE);
 	}
 
 	// pad/joystick navigation

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -46,6 +46,7 @@
 #include "snes9x/cheats.h"
 
 extern SCheatData Cheat;
+extern void ToggleCheat(uint32);
 
 #define THREAD_SLEEP 100
 
@@ -2338,7 +2339,7 @@ static int MenuGameSettings()
 		else if(cheatsBtn.GetState() == STATE_CLICKED)
 		{
 			cheatsBtn.ResetState();
-			if(Cheat.num_cheats > 0)
+			if(Cheat.g.size() > 0)
 				menu = MENU_GAMESETTINGS_CHEATS;
 			else
 				InfoPrompt("Cheats file not found!");
@@ -2387,10 +2388,10 @@ static int MenuGameCheats()
 	u16 i = 0;
 	OptionList options;
 
-	for(i=0; i < Cheat.num_cheats; i++)
+	for(i=0; i < Cheat.g.size(); i++)
 	{
-		snprintf (options.name[i], 50, "%s", Cheat.c[i].name);
-		sprintf (options.value[i], "%s", Cheat.c[i].enabled == true ? "On" : "Off");
+		snprintf (options.name[i], 50, "%s", Cheat.g[i].name);
+		sprintf (options.value[i], "%s", Cheat.g[i].enabled == true ? "On" : "Off");
 	}
 
 	options.length = i;
@@ -2446,11 +2447,8 @@ static int MenuGameCheats()
 
 		if(ret >= 0)
 		{
-			if(Cheat.c[ret].enabled)
-				S9xDisableCheat(ret);
-			else
-				S9xEnableCheat(ret);
-			sprintf (options.value[ret], "%s", Cheat.c[ret].enabled == true ? "On" : "Off");
+			ToggleCheat(ret);
+			sprintf (options.value[ret], "%s", Cheat.g[ret].enabled == true ? "On" : "Off");
 			optionBrowser.TriggerUpdate();
 		}
 

--- a/source/snes9x/bml.cpp
+++ b/source/snes9x/bml.cpp
@@ -1,0 +1,291 @@
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <stack>
+#include <stdio.h>
+
+#include "port.h"
+#include "bml.h"
+
+bml_node::bml_node()
+{
+    type = CHILD;
+    depth = -1;
+}
+
+static inline int islf(char c)
+{
+    return (c == '\r' || c == '\n');
+}
+
+static inline int isblank(char c)
+{
+    return (c == ' ' || c == '\t');
+}
+
+static inline int isblankorlf(char c)
+{
+    return (islf(c) || isblank(c));
+}
+
+static inline int isalnum(char c)
+{
+    return ((c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9'));
+}
+
+static inline int bml_valid(char c)
+{
+    return (isalnum(c) || c == '-');
+}
+
+static std::string trim(std::string str)
+{
+    int start;
+    int end;
+    for (start = 0; str[start] && start != (int)str.length() && isblank(str[start]); start++) {}
+    if (start >= (int)str.length())
+        return std::string("");
+    for (end = str.length() - 1; isblankorlf(str[end]); end--) {}
+    return str.substr(start, end - start + 1);
+}
+
+static std::string trimcomments(std::string str)
+{
+    int end = str.length();
+    size_t comment = str.find("//");
+    if (comment != std::string::npos)
+        end = comment;
+
+    for (int i = end - 1; i >= 0; i--)
+    {
+        if (!isblankorlf(str[i]))
+        {
+            end = i + 1;
+            break;
+        }
+    }
+
+    return str.substr(0, end);
+}
+
+static inline int bml_read_depth(std::string &data)
+{
+    size_t depth;
+    for (depth = 0; isblank(data[depth]) && depth < data.length(); depth++) {}
+    return depth == data.length() ? -1 : depth;
+}
+
+static void bml_parse_depth(bml_node &node, std::string &line)
+{
+    unsigned int depth = bml_read_depth(line);
+    line.erase(0, depth);
+    node.depth = depth;
+}
+
+static void bml_parse_name(bml_node &node, std::string &line)
+{
+    int len;
+
+    for (len = 0; bml_valid(line[len]); len++) {};
+
+    node.name = trim(line.substr(0, len));
+    line.erase(0, len);
+}
+
+static void bml_parse_data(bml_node &node, std::string &line)
+{
+    int len;
+
+    if (line[0] == '=' && line[1] == '\"')
+    {
+        len = 2;
+        while (line[len] && line[len] != '\"' && !islf(line[len]))
+            len++;
+        if (line[len] != '\"')
+            return;
+
+        node.data = line.substr(2, len - 2);
+        line.erase(0, len + 1);
+    }
+    else if (line[0] == '=')
+    {
+        len = 1;
+        while (line[len] && !islf(line[len]) && line[len] != '"' && line[len] != ' ')
+            len++;
+        if (line[len] == '\"')
+            return;
+        node.data = line.substr(1, len - 1);
+        line.erase(0, len);
+    }
+    else if (line[0] == ':')
+    {
+        len = 1;
+        while (line[len] && !islf(line[len]))
+            len++;
+        node.data = trim(line.substr(1, len - 1));
+        line.erase(0, len);
+    }
+
+    return;
+}
+
+static std::string bml_read_line(std::ifstream &fd)
+{
+    std::string line;
+
+    while (fd)
+    {
+        std::getline(fd, line);
+        line = trimcomments(line);
+        if (!line.empty())
+        {
+            return line;
+        }
+    }
+
+    return std::string("");
+}
+
+static void bml_parse_attr(bml_node &node, std::string &line)
+{
+    int len;
+
+    while (line.length() > 0)
+    {
+        if (!isblank(line[0]))
+            return;
+
+        while (isblank(line[0]))
+            line.erase(0, 1);
+
+        bml_node n;
+        len = 0;
+        while (bml_valid(line[len]))
+            len++;
+        if (len == 0)
+            return;
+        n.name = trim(line.substr(0, len));
+        line.erase(0, len);
+        bml_parse_data(n, line);
+        n.depth = node.depth + 1;
+        n.type = bml_node::ATTRIBUTE;
+        node.child.push_back(n);
+    }
+}
+
+static int contains_space(const char *str)
+{
+    for (int i = 0; str[i]; i++)
+    {
+        if (isblank(str[i]))
+            return 1;
+    }
+
+    return 0;
+}
+
+static void bml_print_node(bml_node &node, int depth)
+{
+    int i;
+
+    for (i = 0; i < depth * 2; i++)
+    {
+        printf(" ");
+    }
+
+    if (!node.name.empty())
+        printf("%s", node.name.c_str());
+
+    if (!node.data.empty())
+    {
+        if (contains_space(node.data.c_str()))
+            printf("=\"%s\"", node.data.c_str());
+        else
+            printf(": %s", node.data.c_str());
+    }
+    for (i = 0; i < (int)node.child.size() && node.child[i].type == bml_node::ATTRIBUTE; i++)
+    {
+        if (!node.child[i].name.empty())
+        {
+            printf(" %s", node.child[i].name.c_str());
+            if (!node.child[i].data.empty())
+            {
+                if (contains_space(node.child[i].data.c_str()))
+                    printf("=\"%s\"", node.child[i].data.c_str());
+                else
+                    printf("=%s", node.child[i].data.c_str());
+            }
+        }
+    }
+
+    if (depth >= 0)
+        printf("\n");
+
+    for (; i < (int)node.child.size(); i++)
+    {
+        bml_print_node(node.child[i], depth + 1);
+    }
+
+    if (depth == 0)
+        printf("\n");
+}
+
+void bml_node::print()
+{
+    bml_print_node(*this, -1);
+}
+
+void bml_node::parse(std::ifstream &fd)
+{
+    std::stack<bml_node *> nodestack;
+    nodestack.push(this);
+
+    while (fd)
+    {
+        bml_node newnode;
+        std::string line = bml_read_line(fd);
+        if (line.empty())
+            return;
+
+        int line_depth = bml_read_depth(line);
+        while (line_depth <= nodestack.top()->depth && nodestack.size() > 1)
+            nodestack.pop();
+
+        bml_parse_depth(newnode, line);
+        bml_parse_name(newnode, line);
+        bml_parse_data(newnode, line);
+        bml_parse_attr(newnode, line);
+
+        nodestack.top()->child.push_back(newnode);
+        nodestack.push(&nodestack.top()->child.back());
+    }
+
+    return;
+}
+
+bml_node *bml_node::find_subnode(std::string name)
+{
+    unsigned int i;
+
+    for (i = 0; i < child.size(); i++)
+    {
+        if (name.compare(child[i].name) == 0)
+            return &child[i];
+    }
+
+    return NULL;
+}
+
+bool bml_node::parse_file(std::string filename)
+{
+    std::ifstream file(filename.c_str(), std::ios_base::binary);
+
+    if (!file)
+        return false;
+
+    parse(file);
+
+    return true;
+}

--- a/source/snes9x/bml.h
+++ b/source/snes9x/bml.h
@@ -1,0 +1,27 @@
+#ifndef __BML_H
+#define __BML_H
+#include <vector>
+#include <string>
+#include <fstream>
+
+struct bml_node
+{
+    enum node_type {
+        CHILD,
+        ATTRIBUTE
+    };
+
+    bml_node();
+    bool parse_file(std::string filename);
+    void parse(std::ifstream &fd);
+    bml_node *find_subnode(std::string name);
+    void print();
+
+    std::string name;
+    std::string data;
+    int depth;
+    std::vector<bml_node> child;
+    node_type type;
+};
+
+#endif

--- a/source/snes9x/cheats.h
+++ b/source/snes9x/cheats.h
@@ -4,26 +4,35 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
-
 #ifndef _CHEATS_H_
 #define _CHEATS_H_
 
-#define MAX_CHEATS	150
+#include "port.h"
+#include "bml.h"
+#include <vector>
 
 struct SCheat
 {
 	uint32	address;
 	uint8	byte;
 	uint8	saved_byte;
+	bool8	conditional;
+	bool8	cond_true;
+	uint8	cond_byte;
 	bool8	enabled;
-	bool8	saved;
-	char	name[22];
+};
+
+struct SCheatGroup
+{
+	char *name;
+	bool8 enabled;
+	std::vector<struct SCheat> c;
 };
 
 struct SCheatData
 {
-	struct SCheat c[MAX_CHEATS];
-	uint32	num_cheats;
+	std::vector<struct SCheatGroup> g;
+	bool8	enabled;
 	uint8	CWRAM[0x20000];
 	uint8	CSRAM[0x80000];
 	uint8	CIRAM[0x2000];
@@ -65,25 +74,29 @@ typedef enum
 extern SCheatData	Cheat;
 extern Watch		watches[16];
 
-void S9xApplyCheat (uint32);
-void S9xApplyCheats (void);
-void S9xRemoveCheat (uint32);
-void S9xRemoveCheats (void);
-void S9xDeleteCheat (uint32);
+int S9xAddCheatGroup (const char *name, const char *cheat);
+int S9xModifyCheatGroup (uint32 index, const char *name, const char *cheat);
+void S9xEnableCheatGroup (uint32 index);
+void S9xDisableCheatGroup (uint32 index);
 void S9xDeleteCheats (void);
-void S9xEnableCheat (uint32);
-void S9xDisableCheat (uint32);
-void S9xAddCheat (bool8, bool8, uint32, uint8);
+char *S9xCheatGroupToText (uint32 index);
+void S9xDeleteCheatGroup (uint32 index);
+bool8 S9xLoadCheatFile (const char *filename);
+bool8 S9xSaveCheatFile (const char *filename);
+void S9xUpdateCheatsInMemory (void);
+int S9xImportCheatsFromDatabase(const char *filename);
+void S9xCheatsDisable (void);
+void S9xCheatsEnable (void);
+char *S9xCheatValidate (const char *cheat);
+
 void S9xInitCheatData (void);
 void S9xInitWatchedAddress (void);
-bool8 S9xLoadCheatFile (const char *);
-bool8 S9xSaveCheatFile (const char *);
-
 void S9xStartCheatSearch (SCheatData *);
 void S9xSearchForChange (SCheatData *, S9xCheatComparisonType, S9xCheatDataSize, bool8, bool8);
 void S9xSearchForValue (SCheatData *, S9xCheatComparisonType, S9xCheatDataSize, uint32, bool8, bool8);
 void S9xSearchForAddress (SCheatData *, S9xCheatComparisonType, S9xCheatDataSize, uint32, bool8);
 void S9xOutputCheatSearchResults (SCheatData *);
+void S9xLoadCheatsFromBMLNode (bml_node *);
 
 const char * S9xGameGenieToRaw (const char *, uint32 &, uint8 &);
 const char * S9xProActionReplayToRaw (const char *, uint32 &, uint8 &);

--- a/source/snes9x/cheats2.cpp
+++ b/source/snes9x/cheats2.cpp
@@ -4,233 +4,764 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
+#include <ctype.h>
 
 #include "snes9x.h"
 #include "memmap.h"
 #include "cheats.h"
+#include "bml.h"
 
-static uint8 S9xGetByteFree (uint32);
-static void S9xSetByteFree (uint8, uint32);
-
-
-static uint8 S9xGetByteFree (uint32 address)
+static inline char *trim (char *string)
 {
-	uint32	Cycles = CPU.Cycles;
-	uint32	WaitAddress = CPU.WaitAddress;
-	uint8	byte;
+    int start;
+    int end;
 
-	byte = S9xGetByte(address);
-
-	CPU.WaitAddress = WaitAddress;
-	CPU.Cycles = Cycles;
-
-	return (byte);
+    for (start = 0; string[start] && isspace (string[start]); start++) {}
+    for (end = start; string[end] && !isspace (string[end]); end++) {}
+    string[end] = '\0';
+    return &string[start];
 }
 
-static void S9xSetByteFree (uint8 byte, uint32 address)
+static inline uint8 S9xGetByteFree (uint32 Address)
 {
-	uint32	Cycles = CPU.Cycles;
-	uint32	WaitAddress = CPU.WaitAddress;
+    int	block = (Address & 0xffffff) >> MEMMAP_SHIFT;
+    uint8 *GetAddress = Memory.Map[block];
+    uint8 byte;
 
-	S9xSetByte(byte, address);
+    if (GetAddress >= (uint8 *) CMemory::MAP_LAST)
+    {
+        byte = *(GetAddress + (Address & 0xffff));
+        return (byte);
+    }
 
-	CPU.WaitAddress = WaitAddress;
-	CPU.Cycles = Cycles;
+    switch ((pint) GetAddress)
+    {
+    case CMemory::MAP_CPU:
+        byte = S9xGetCPU(Address & 0xffff);
+        return (byte);
+
+    case CMemory::MAP_PPU:
+        if (CPU.InDMAorHDMA && (Address & 0xff00) == 0x2100)
+            return (OpenBus);
+
+        byte = S9xGetPPU(Address & 0xffff);
+        return (byte);
+
+    case CMemory::MAP_LOROM_SRAM:
+    case CMemory::MAP_SA1RAM:
+        // Address & 0x7fff   : offset into bank
+        // Address & 0xff0000 : bank
+        // bank >> 1 | offset : SRAM address, unbound
+        // unbound & SRAMMask : SRAM offset
+        byte = *(Memory.SRAM + ((((Address & 0xff0000) >> 1) | (Address & 0x7fff)) & Memory.SRAMMask));
+        return (byte);
+
+    case CMemory::MAP_LOROM_SRAM_B:
+        byte = *(Multi.sramB + ((((Address & 0xff0000) >> 1) | (Address & 0x7fff)) & Multi.sramMaskB));
+        return (byte);
+
+    case CMemory::MAP_HIROM_SRAM:
+    case CMemory::MAP_RONLY_SRAM:
+        byte = *(Memory.SRAM + (((Address & 0x7fff) - 0x6000 + ((Address & 0x1f0000) >> 3)) & Memory.SRAMMask));
+        return (byte);
+
+    case CMemory::MAP_BWRAM:
+        byte = *(Memory.BWRAM + ((Address & 0x7fff) - 0x6000));
+        return (byte);
+
+    case CMemory::MAP_DSP:
+        byte = S9xGetDSP(Address & 0xffff);
+        return (byte);
+
+    case CMemory::MAP_SPC7110_ROM:
+        byte = S9xGetSPC7110Byte(Address);
+        return (byte);
+
+    case CMemory::MAP_SPC7110_DRAM:
+        byte = S9xGetSPC7110(0x4800);
+        return (byte);
+
+    case CMemory::MAP_C4:
+        byte = S9xGetC4(Address & 0xffff);
+        return (byte);
+
+    case CMemory::MAP_OBC_RAM:
+        byte = S9xGetOBC1(Address & 0xffff);
+        return (byte);
+
+    case CMemory::MAP_SETA_DSP:
+        byte = S9xGetSetaDSP(Address);
+        return (byte);
+
+    case CMemory::MAP_SETA_RISC:
+        byte = S9xGetST018(Address);
+        return (byte);
+
+    case CMemory::MAP_BSX:
+        byte = S9xGetBSX(Address);
+        return (byte);
+
+    case CMemory::MAP_NONE:
+    default:
+        byte = OpenBus;
+        return (byte);
+    }
+}
+
+static inline void S9xSetByteFree (uint8 Byte, uint32 Address)
+{
+    int block = (Address & 0xffffff) >> MEMMAP_SHIFT;
+    uint8 *SetAddress = Memory.Map[block];
+
+    if (SetAddress >= (uint8 *) CMemory::MAP_LAST)
+    {
+        *(SetAddress + (Address & 0xffff)) = Byte;
+        return;
+    }
+
+    switch ((pint) SetAddress)
+    {
+    case CMemory::MAP_CPU:
+        S9xSetCPU(Byte, Address & 0xffff);
+        return;
+
+    case CMemory::MAP_PPU:
+        if (CPU.InDMAorHDMA && (Address & 0xff00) == 0x2100)
+            return;
+
+        S9xSetPPU(Byte, Address & 0xffff);
+        return;
+
+    case CMemory::MAP_LOROM_SRAM:
+        if (Memory.SRAMMask)
+        {
+            *(Memory.SRAM + ((((Address & 0xff0000) >> 1) | (Address & 0x7fff)) & Memory.SRAMMask)) = Byte;
+            CPU.SRAMModified = TRUE;
+        }
+
+        return;
+
+    case CMemory::MAP_LOROM_SRAM_B:
+        if (Multi.sramMaskB)
+        {
+            *(Multi.sramB + ((((Address & 0xff0000) >> 1) | (Address & 0x7fff)) & Multi.sramMaskB)) = Byte;
+            CPU.SRAMModified = TRUE;
+        }
+
+        return;
+
+    case CMemory::MAP_HIROM_SRAM:
+        if (Memory.SRAMMask)
+        {
+            *(Memory.SRAM + (((Address & 0x7fff) - 0x6000 + ((Address & 0x1f0000) >> 3)) & Memory.SRAMMask)) = Byte;
+            CPU.SRAMModified = TRUE;
+        }
+        return;
+
+    case CMemory::MAP_BWRAM:
+        *(Memory.BWRAM + ((Address & 0x7fff) - 0x6000)) = Byte;
+        CPU.SRAMModified = TRUE;
+        return;
+
+    case CMemory::MAP_SA1RAM:
+        *(Memory.SRAM + (Address & 0xffff)) = Byte;
+        return;
+
+    case CMemory::MAP_DSP:
+        S9xSetDSP(Byte, Address & 0xffff);
+        return;
+
+    case CMemory::MAP_C4:
+        S9xSetC4(Byte, Address & 0xffff);
+        return;
+
+    case CMemory::MAP_OBC_RAM:
+        S9xSetOBC1(Byte, Address & 0xffff);
+        return;
+
+    case CMemory::MAP_SETA_DSP:
+        S9xSetSetaDSP(Byte, Address);
+        return;
+
+    case CMemory::MAP_SETA_RISC:
+        S9xSetST018(Byte, Address);
+        return;
+
+    case CMemory::MAP_BSX:
+        S9xSetBSX(Byte, Address);
+        return;
+
+    case CMemory::MAP_NONE:
+    default:
+        return;
+    }
 }
 
 void S9xInitWatchedAddress (void)
 {
-	for (unsigned int i = 0; i < sizeof(watches) / sizeof(watches[0]); i++)
-		watches[i].on = false;
-
+    for (unsigned int i = 0; i < sizeof(watches) / sizeof(watches[0]); i++)
+        watches[i].on = false;
 }
 
 void S9xInitCheatData (void)
 {
-	Cheat.RAM = Memory.RAM;
-	Cheat.SRAM = Memory.SRAM;
-	Cheat.FillRAM = Memory.FillRAM;
+    Cheat.RAM = Memory.RAM;
+    Cheat.SRAM = Memory.SRAM;
+    Cheat.FillRAM = Memory.FillRAM;
 }
 
-void S9xAddCheat (bool8 enable, bool8 save_current_value, uint32 address, uint8 byte)
+
+void S9xUpdateCheatInMemory (SCheat *c)
 {
-	if (Cheat.num_cheats < sizeof(Cheat.c) / sizeof(Cheat.c[0]))
-	{
-		Cheat.c[Cheat.num_cheats].address = address;
-		Cheat.c[Cheat.num_cheats].byte = byte;
-		Cheat.c[Cheat.num_cheats].enabled = enable;
+    uint8 byte;
 
-		if (save_current_value)
-		{
-			Cheat.c[Cheat.num_cheats].saved_byte = S9xGetByteFree(address);
-			Cheat.c[Cheat.num_cheats].saved = TRUE;
-		}
+    if (!c->enabled)
+        return;
 
-		Cheat.num_cheats++;
-	}
+    byte = S9xGetByteFree (c->address);
+
+    if (byte != c->byte)
+    {
+        /* The game wrote a different byte to the address, update saved_byte */
+        c->saved_byte = byte;
+
+        if (c->conditional)
+        {
+            if (c->saved_byte != c->cond_byte && c->cond_true)
+            {
+                /* Condition is now false, let the byte stand */
+                c->cond_true = false;
+            }
+            else if (c->saved_byte == c->cond_byte && !c->cond_true)
+            {
+                c->cond_true = true;
+                S9xSetByteFree (c->byte, c->address);
+            }
+        }
+        else
+            S9xSetByteFree (c->byte, c->address);
+    }
+    else if (c->conditional)
+    {
+        if (byte == c->cond_byte)
+        {
+            c->cond_true = true;
+            c->saved_byte = byte;
+            S9xSetByteFree (c->byte, c->address);
+        }
+    }
 }
 
-void S9xDeleteCheat (uint32 which1)
+void S9xDisableCheat (SCheat *c)
 {
-	if (which1 < Cheat.num_cheats)
-	{
-		if (Cheat.c[which1].enabled)
-			S9xRemoveCheat(which1);
+    if (!c->enabled)
+        return;
 
-		memmove(&Cheat.c[which1], &Cheat.c[which1 + 1], sizeof(Cheat.c[0]) * (Cheat.num_cheats - which1 - 1));
+    if (!Cheat.enabled)
+    {
+        c->enabled = false;
+        return;
+    }
 
-		Cheat.num_cheats--;
-	}
+    /* Make sure we restore the up-to-date written byte */
+    S9xUpdateCheatInMemory (c);
+    c->enabled = false;
+
+    if (c->conditional && !c->cond_true)
+        return;
+
+    S9xSetByteFree (c->saved_byte, c->address);
+    c->cond_true = false;
+}
+
+void S9xDeleteCheatGroup (uint32 g)
+{
+    unsigned int i;
+
+    if (g >= Cheat.g.size ())
+        return;
+
+    for (i = 0; i < Cheat.g[g].c.size (); i++)
+    {
+        S9xDisableCheat (&Cheat.g[g].c[i]);
+    }
+
+    delete[] Cheat.g[g].name;
+
+    Cheat.g.erase (Cheat.g.begin () + g);
 }
 
 void S9xDeleteCheats (void)
 {
-	S9xRemoveCheats();
-	Cheat.num_cheats = 0;
+    unsigned int i;
+
+    for (i = 0; i < Cheat.g.size (); i++)
+    {
+        S9xDisableCheatGroup (i);
+
+        delete[] Cheat.g[i].name;
+    }
+
+    Cheat.g.clear ();
 }
 
-void S9xRemoveCheat (uint32 which1)
+void S9xEnableCheat (SCheat *c)
 {
-	if (Cheat.c[which1].saved)
-	{
-		uint32	address = Cheat.c[which1].address;
+    uint8 byte;
 
-		int		block = (address & 0xffffff) >> MEMMAP_SHIFT;
-		uint8	*ptr = Memory.Map[block];
+    if (c->enabled)
+        return;
 
-		if (ptr >= (uint8 *) CMemory::MAP_LAST)
-			ptr[address & 0xffff] = Cheat.c [which1].saved_byte;
-		else
-			S9xSetByteFree(Cheat.c[which1].saved_byte, address);
-	}
+    c->enabled = true;
+
+    if (!Cheat.enabled)
+        return;
+
+    byte = S9xGetByteFree(c->address);
+
+    if (c->conditional)
+    {
+        if (byte != c->cond_byte)
+            return;
+
+        c->cond_true = true;
+    }
+
+    c->saved_byte = byte;
+    S9xSetByteFree (c->byte, c->address);
 }
 
-void S9xRemoveCheats (void)
+void S9xEnableCheatGroup (uint32 num)
 {
-	for (uint32 i = 0; i < Cheat.num_cheats; i++)
-		if (Cheat.c[i].enabled)
-			S9xRemoveCheat(i);
+    unsigned int i;
+
+    for (i = 0; i < Cheat.g[num].c.size (); i++)
+    {
+        S9xEnableCheat (&Cheat.g[num].c[i]);
+    }
+
+    Cheat.g[num].enabled = true;
 }
 
-void S9xEnableCheat (uint32 which1)
+void S9xDisableCheatGroup (uint32 num)
 {
-	if (which1 < Cheat.num_cheats && !Cheat.c[which1].enabled)
-	{
-		Cheat.c[which1].enabled = TRUE;
-		S9xApplyCheat(which1);
-	}
+    unsigned int i;
+
+    for (i = 0; i < Cheat.g[num].c.size (); i++)
+    {
+        S9xDisableCheat (&Cheat.g[num].c[i]);
+    }
+
+    Cheat.g[num].enabled = false;
 }
 
-void S9xDisableCheat (uint32 which1)
+SCheat S9xTextToCheat (char *text)
 {
-	if (which1 < Cheat.num_cheats && Cheat.c[which1].enabled)
-	{
-		S9xRemoveCheat(which1);
-		Cheat.c[which1].enabled = FALSE;
-	}
+    SCheat c;
+    unsigned int byte = 0;
+    unsigned int cond_byte = 0;
+
+    c.enabled     = false;
+    c.conditional = false;
+
+    if (!S9xGameGenieToRaw (text, c.address, c.byte))
+    {
+        byte = c.byte;
+    }
+
+    else if (!S9xProActionReplayToRaw (text, c.address, c.byte))
+    {
+        byte = c.byte;
+    }
+
+    else if (sscanf (text, "%x = %x ? %x", &c.address, &cond_byte, &byte) == 3)
+    {
+        c.conditional = true;
+    }
+
+    else if (sscanf (text, "%x = %x", &c.address, &byte) == 2)
+    {
+    }
+
+    else if (sscanf (text, "%x / %x / %x", &c.address, &cond_byte, &byte) == 3)
+    {
+        c.conditional = true;
+    }
+
+    else if (sscanf (text, "%x / %x", &c.address, &byte) == 2)
+    {
+    }
+
+    else
+    {
+        c.address = 0;
+        byte = 0;
+    }
+
+    c.byte = byte;
+    c.cond_byte = cond_byte;
+
+    return c;
 }
 
-void S9xApplyCheat (uint32 which1)
+SCheatGroup S9xCreateCheatGroup (const char *name, const char *cheat)
 {
-	uint32	address = Cheat.c[which1].address;
+    SCheatGroup g;
+    char *code_string = strdup (cheat);
+    char *code_ptr = code_string;
+    int len;
 
-	if (!Cheat.c[which1].saved)
-	{
-		Cheat.c[which1].saved_byte = S9xGetByteFree(address);
-		Cheat.c[which1].saved = TRUE;
-	}
+    g.name = strdup (name);
+    g.enabled = false;
 
-	int		block = (address & 0xffffff) >> MEMMAP_SHIFT;
-	uint8	*ptr = Memory.Map[block];
+    for (len = strcspn (code_ptr, "+"); len; len = strcspn (code_ptr, "+"))
+    {
+        char *code = code_ptr;
+        code_ptr += len + (code_ptr[len] == '\0' ? 0 : 1);
+        code[len] = '\0';
+        code = trim (code);
 
-	if (ptr >= (uint8 *) CMemory::MAP_LAST)
-		ptr[address & 0xffff] = Cheat.c [which1].byte;
-	else
-		S9xSetByteFree(Cheat.c[which1].byte, address);
+        SCheat c = S9xTextToCheat (code);
+        if (c.address)
+            g.c.push_back (c);
+    }
+
+    free(code_string);
+
+    return g;
 }
 
-void S9xApplyCheats (void)
+int S9xAddCheatGroup (const char *name, const char *cheat)
 {
-	if (Settings.ApplyCheats)
-	{
-		for (uint32 i = 0; i < Cheat.num_cheats; i++)
-			if (Cheat.c[i].enabled)
-				S9xApplyCheat(i);
-	}
+    SCheatGroup g = S9xCreateCheatGroup (name, cheat);
+    if (g.c.size () == 0)
+        return -1;
+
+    Cheat.g.push_back (g);
+
+    return Cheat.g.size () - 1;
+}
+
+int S9xModifyCheatGroup (uint32 num, const char *name, const char *cheat)
+{
+	if (num >= Cheat.g.size())
+		return -1;
+
+    S9xDisableCheatGroup (num);
+    delete[] Cheat.g[num].name;
+
+    Cheat.g[num] = S9xCreateCheatGroup (name, cheat);
+
+    return num;
+}
+
+char *S9xCheatToText (SCheat *c)
+{
+    int size = 10; /* 6 address, 1 =, 2 byte, 1 NUL */
+    char *text;
+
+    if (c->conditional)
+        size += 3; /* additional 2 byte, 1 ? */
+
+    text = new char[size];
+
+    if (c->conditional)
+        snprintf (text, size, "%06x=%02x?%02x", c->address, c->cond_byte, c->byte);
+    else
+        snprintf (text, size, "%06x=%02x", c->address, c->byte);
+
+    return text;
+}
+
+char *S9xCheatGroupToText (SCheatGroup *g)
+{
+    std::string text = "";
+    unsigned int i;
+
+    if (g->c.size () == 0)
+        return NULL;
+
+    for (i = 0; i < g->c.size (); i++)
+    {
+        char *tmp = S9xCheatToText (&g->c[i]);
+        if (i != 0)
+            text += " + ";
+        text += tmp;
+        delete[] tmp;
+    }
+
+    return strdup (text.c_str ());
+}
+
+char *S9xCheatValidate (const char *code_string)
+{
+    SCheatGroup g = S9xCreateCheatGroup ("temp", code_string);
+
+    delete[] g.name;
+
+    if (g.c.size() > 0)
+    {
+        return S9xCheatGroupToText (&g);
+    }
+
+    return NULL;
+}
+
+char *S9xCheatGroupToText (uint32 num)
+{
+    if (num >= Cheat.g.size ())
+        return NULL;
+
+    return S9xCheatGroupToText (&Cheat.g[num]);
+}
+
+void S9xUpdateCheatsInMemory (void)
+{
+    unsigned int i;
+    unsigned int j;
+
+    if (!Cheat.enabled)
+        return;
+
+    for (i = 0; i < Cheat.g.size (); i++)
+    {
+        for (j = 0; j < Cheat.g[i].c.size (); j++)
+        {
+            S9xUpdateCheatInMemory (&Cheat.g[i].c[j]);
+        }
+    }
+}
+
+static int S9xCheatIsDuplicate (const char *name, const char *code)
+{
+    unsigned int i;
+
+    for (i = 0; i < Cheat.g.size(); i++)
+    {
+        if (!strcmp (name, Cheat.g[i].name))
+        {
+            char *code_string = S9xCheatGroupToText (i);
+            char *validated   = S9xCheatValidate (code);
+
+            if (validated && !strcmp (code_string, validated))
+            {
+                free (code_string);
+                free (validated);
+                return TRUE;
+            }
+
+            free (code_string);
+            free (validated);
+        }
+    }
+
+    return FALSE;
+}
+
+void S9xLoadCheatsFromBMLNode (bml_node *n)
+{
+    unsigned int i;
+
+    for (i = 0; i < n->child.size (); i++)
+    {
+        if (!strcasecmp (n->child[i].name.c_str(), "cheat"))
+        {
+            const char *desc = NULL;
+            const char *code = NULL;
+            bool8 enabled = false;
+
+            bml_node *c = &n->child[i];
+            bml_node *tmp = NULL;
+
+            tmp = c->find_subnode("name");
+            if (!tmp)
+                desc = (char *) "";
+            else
+                desc = tmp->data.c_str();
+
+            tmp = c->find_subnode("code");
+            if (tmp)
+                code = tmp->data.c_str();
+
+            if (c->find_subnode("enable"))
+                enabled = true;
+
+            if (code && !S9xCheatIsDuplicate (desc, code))
+            {
+                int index = S9xAddCheatGroup (desc, code);
+
+                if (enabled)
+                    S9xEnableCheatGroup (index);
+            }
+        }
+    }
+
+    return;
+}
+
+static bool8 S9xLoadCheatFileClassic (const char *filename)
+{
+    FILE *fs;
+    uint8 data[28];
+
+    fs = fopen(filename, "rb");
+    if (!fs)
+        return (FALSE);
+
+    while (fread ((void *) data, 1, 28, fs) == 28)
+    {
+        SCheat c;
+        char name[21];
+        char cheat[10];
+        c.enabled = (data[0] & 4) == 0;
+        c.byte = data[1];
+        c.address = data[2] | (data[3] << 8) |  (data[4] << 16);
+        memcpy (name, &data[8], 20);
+        name[20] = 0;
+
+        snprintf (cheat, 10, "%x=%x", c.address, c.byte);
+        S9xAddCheatGroup (name, cheat);
+
+        if (c.enabled)
+            S9xEnableCheatGroup (Cheat.g.size () - 1);
+    }
+
+    fclose(fs);
+
+    return (TRUE);
 }
 
 bool8 S9xLoadCheatFile (const char *filename)
 {
-	FILE	*fs;
-	uint8	data[28];
+    bml_node bml;
+    if (!bml.parse_file(filename))
+    {
+        return S9xLoadCheatFileClassic (filename);
+    }
 
-	Cheat.num_cheats = 0;
+    bml_node *n = bml.find_subnode("cheat");
+    if (n)
+    {
+        S9xLoadCheatsFromBMLNode (&bml);
+    }
 
-	fs = fopen(filename, "rb");
-	if (!fs)
-		return (FALSE);
+    if (!n)
+    {
+        return S9xLoadCheatFileClassic (filename);
+    }
 
-	while (fread((void *) data, 1, 28, fs) == 28)
-	{
-		Cheat.c[Cheat.num_cheats].enabled = (data[0] & 4) == 0;
-		Cheat.c[Cheat.num_cheats].byte = data[1];
-		Cheat.c[Cheat.num_cheats].address = data[2] | (data[3] << 8) |  (data[4] << 16);
-		Cheat.c[Cheat.num_cheats].saved_byte = data[5];
-		Cheat.c[Cheat.num_cheats].saved = (data[0] & 8) != 0;
-		memmove(Cheat.c[Cheat.num_cheats].name, &data[8], 20);
-		Cheat.c[Cheat.num_cheats++].name[20] = 0;
-	}
-
-	fclose(fs);
-
-	return (TRUE);
+    return (TRUE);
 }
 
 bool8 S9xSaveCheatFile (const char *filename)
 {
-	if (Cheat.num_cheats == 0)
-	{
-		remove(filename);
-		return (TRUE);
-	}
+    unsigned int i;
+    FILE *file = NULL;
 
-	FILE	*fs;
-	uint8	data[28];
+    if (Cheat.g.size () == 0)
+    {
+        remove (filename);
+        return TRUE;
+    }
 
-	fs = fopen(filename, "wb");
-	if (!fs)
-		return (FALSE);
+    file = fopen (filename, "w");
 
-	for (uint32 i = 0; i < Cheat.num_cheats; i++)
-	{
-		ZeroMemory(data, 28);
+    if (!file)
+        return FALSE;
 
-		if (i == 0)
-		{
-			data[6] = 254;
-			data[7] = 252;
-		}
+    for (i = 0; i < Cheat.g.size (); i++)
+    {
+        char *txt = S9xCheatGroupToText (i);
 
-		if (!Cheat.c[i].enabled)
-			data[0] |= 4;
+        fprintf (file,
+                 "cheat\n"
+                 "  name: %s\n"
+                 "  code: %s\n"
+                 "%s\n",
+                 Cheat.g[i].name ? Cheat.g[i].name : "",
+                 txt,
+                 Cheat.g[i].enabled ? "  enable\n" : ""
+                 );
 
-		if (Cheat.c[i].saved)
-			data[0] |= 8;
+        delete[] txt;
+    }
 
-		data[1] = Cheat.c[i].byte;
-		data[2] = (uint8) (Cheat.c[i].address >> 0);
-		data[3] = (uint8) (Cheat.c[i].address >> 8);
-		data[4] = (uint8) (Cheat.c[i].address >> 16);
-		data[5] = Cheat.c[i].saved_byte;
+    fclose (file);
 
-		memmove(&data[8], Cheat.c[i].name, 19);
+    return TRUE;
+}
 
-		if (fwrite(data, 28, 1, fs) != 1)
-		{
-			fclose(fs);
-			return (FALSE);
-		}
-	}
+void S9xCheatsDisable (void)
+{
+    unsigned int i;
 
-	return (fclose(fs) == 0);
+    if (!Cheat.enabled)
+        return;
+
+    for (i = 0; i < Cheat.g.size (); i++)
+    {
+        if (Cheat.g[i].enabled)
+        {
+            S9xDisableCheatGroup (i);
+            Cheat.g[i].enabled = TRUE;
+        }
+    }
+
+    Cheat.enabled = FALSE;
+}
+
+void S9xCheatsEnable (void)
+{
+    unsigned int i;
+
+    if (Cheat.enabled)
+        return;
+
+    Cheat.enabled = TRUE;
+
+    for (i = 0; i < Cheat.g.size (); i++)
+    {
+        if (Cheat.g[i].enabled)
+        {
+            Cheat.g[i].enabled = FALSE;
+            S9xEnableCheatGroup (i);
+        }
+    }
+}
+
+int S9xImportCheatsFromDatabase (const char *filename)
+{
+    char sha256_txt[65];
+    char hextable[] = "0123456789abcdef";
+    unsigned int i;
+
+    bml_node bml;
+    if (!bml.parse_file(filename))
+        return -1; // No file
+
+    for (i = 0; i < 32; i++)
+    {
+        sha256_txt[i * 2]     = hextable[Memory.ROMSHA256[i] >> 4];
+        sha256_txt[i * 2 + 1] = hextable[Memory.ROMSHA256[i] & 0xf];
+    }
+    sha256_txt[64] = '\0';
+
+    for (i = 0; i < bml.child.size (); i++)
+    {
+        if (!strcasecmp (bml.child[i].name.c_str(), "cartridge"))
+        {
+            bml_node *n;
+
+            if ((n = bml.child[i].find_subnode ("sha256")))
+            {
+                if (!strcasecmp (n->data.c_str(), sha256_txt))
+                {
+                    S9xLoadCheatsFromBMLNode (&bml.child[i]);
+                    return 0;
+                }
+            }
+        }
+    }
+
+    return -2; /* No codes */
 }

--- a/source/snes9x/gfx.cpp
+++ b/source/snes9x/gfx.cpp
@@ -260,7 +260,7 @@ void S9xEndScreenRefresh (void)
 	else
 		S9xControlEOF();
 
-	S9xApplyCheats();
+	S9xUpdateCheatsInMemory();
 
 #ifdef DEBUGGER
 	if (CPU.Flags & FRAME_ADVANCE_FLAG)

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -1574,7 +1574,7 @@ again:
 	InitROM();
 
 	S9xInitCheatData();
-	S9xApplyCheats();
+	S9xUpdateCheatsInMemory();
 
 	S9xReset();
 
@@ -1648,7 +1648,7 @@ bool8 CMemory::LoadMultiCart (const char *cartA, const char *cartB)
 	InitROM();
 
 	S9xInitCheatData();
-	S9xApplyCheats();
+	S9xUpdateCheatsInMemory();
 
 	S9xReset();
 

--- a/source/snes9x/memmap.h
+++ b/source/snes9x/memmap.h
@@ -91,6 +91,7 @@ struct CMemory
 	uint32	ROMChecksum;
 	uint32	ROMComplementChecksum;
 	uint32	ROMCRC32;
+	unsigned char ROMSHA256[32];
 	int32	ROMFramesPerSecond;
 
 	bool8	HiROM;


### PR DESCRIPTION
These changes bring in support into RX for the new style .cht format. While it's technically an update to the core (from Snes9x version 1.56+), I don't think it would have any impact on performance.

Both old and new format .cht files should work now in RX. For the new .cht format, each cheat's text should now scroll if the name is too long to fit in the OptionBrowser.